### PR TITLE
use the same mutex in Stabilizer as that in AutobalanceStabilizer

### DIFF
--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -144,7 +144,7 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onInitialize()
     }
 
     fik = std::make_unique<hrp::FullbodyInverseKinematicsSolver>(m_robot, std::string(m_profile.instance_name), m_dt);
-    st = std::make_unique<hrp::Stabilizer>(m_robot, std::string(m_profile.instance_name) + "_ST", m_dt);
+    st = std::make_unique<hrp::Stabilizer>(m_robot, std::string(m_profile.instance_name) + "_ST", m_dt, m_mutex);
     {
         std::vector<hrp::LinkConstraint> init_constraints = readContactPointsFromProps(prop);
 

--- a/rtc/AutoBalanceStabilizer/Stabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/Stabilizer.cpp
@@ -29,10 +29,11 @@ inline bool DEBUGP(unsigned int loop) { return (DEBUG_LEVEL == 1 && loop % 200 =
 
 namespace hrp {
 
-Stabilizer::Stabilizer(const hrp::BodyPtr& _robot, const std::string& _comp_name, const double _dt)
+Stabilizer::Stabilizer(const hrp::BodyPtr& _robot, const std::string& _comp_name, const double _dt, std::mutex& _mutex)
     : m_robot(boost::make_shared<hrp::Body>(*_robot)),
       comp_name(_comp_name),
-      dt(_dt)
+      dt(_dt),
+      m_mutex(_mutex)
 {
     limb_stretch_avoidance_vlimit[0] = -100 * 1e-3 * dt; // lower limit
     limb_stretch_avoidance_vlimit[1] = 50 * 1e-3 * dt; // upper limit

--- a/rtc/AutoBalanceStabilizer/Stabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/Stabilizer.cpp
@@ -1570,6 +1570,7 @@ void Stabilizer::startStabilizer()
         std::cerr << "[" << comp_name << "] " << "Moved to ST command pose and sync to TORQUE mode"  << std::endl;
         constexpr double DEFAULT_TRANSITION_TIME = 2.0;
 
+        std::lock_guard<std::mutex> lock(m_mutex);
         for (size_t i = 0; i < m_robot->numJoints(); ++i) {
             servo_pgains[i] = 100;
             servo_dgains[i] = 100;

--- a/rtc/AutoBalanceStabilizer/Stabilizer.h
+++ b/rtc/AutoBalanceStabilizer/Stabilizer.h
@@ -67,7 +67,7 @@ struct stabilizerPortData
 class Stabilizer
 {
   public:
-    Stabilizer(const hrp::BodyPtr& _robot, const std::string& _comp_name, const double _dt);
+    Stabilizer(const hrp::BodyPtr& _robot, const std::string& _comp_name, const double _dt, std::mutex& _mutex);
     virtual ~Stabilizer() {};
 
     void initStabilizer(const RTC::Properties& prop, const size_t ee_num);
@@ -275,7 +275,7 @@ class Stabilizer
     };
 
     hrp::BodyPtr m_robot;
-    std::mutex m_mutex;
+    std::mutex& m_mutex; // This is the reference to the mutex of AutoBalanceStabilizer class
     const std::string comp_name;
     const double dt;
     unsigned int loop = 0;


### PR DESCRIPTION
AutobalanceStabilzierとStabilizerで共通のm_mutexを使うようにしました．
また，startStabilizerのトルクゲインを変更する部分もロックして，確実にトルクゲインが変更されるようになりました．