### PR TITLE
set current constraints coords to foot coords unless walking(running)

### DIFF
--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -374,6 +374,7 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onExecute(RTC::UniqueId ec_id)
         // 脚軌道, COP, RootLink計算
         gg->forwardTimeStep(loop);
         gg->calcCogAndLimbTrajectory(loop, m_dt);
+        gg_is_walking = gg->getWalkingState();
         ref_zmp = gg->getRefZMP();
 
         // TODO: rootlink計算
@@ -1395,7 +1396,7 @@ bool AutoBalanceStabilizer::startWalking()
 
 void AutoBalanceStabilizer::stopWalking ()
 {
-    gg_is_walking = false;
+    gg->setWalkingState(false);
 }
 
 bool AutoBalanceStabilizer::startAutoBalancer(const OpenHRP::AutoBalanceStabilizerService::StrSequence& limbs)
@@ -1492,7 +1493,7 @@ bool AutoBalanceStabilizer::goPos(const double x, const double y, const double t
     if (!gg->goPos(target, support_link_cycle, swing_link_cycle)) return false;
 
     Guard guard(m_mutex);
-    gg_is_walking = true; // TODO: 自動でgg_is_walkingをfalseにする & constraintsのclear
+    gg->setWalkingState(true);
 
     return true;
 }
@@ -1562,7 +1563,7 @@ bool AutoBalanceStabilizer::setFootSteps(const OpenHRP::AutoBalanceStabilizerSer
     if (!gg->setFootSteps(support_link_cycle, swing_link_cycle, footsteps_pos, footsteps_rot, fs_side, length)) return false;
 
     Guard guard(m_mutex);
-    gg_is_walking = true; // TODO: 自動でgg_is_walkingをfalseにする & constraintsのclear
+    gg->setWalkingState(true);
 
     return true;
 }
@@ -1632,7 +1633,7 @@ bool AutoBalanceStabilizer::setRunningFootSteps(const OpenHRP::AutoBalanceStabil
     if (!gg->setRunningFootSteps(support_link_cycle, swing_link_cycle, footsteps_pos, footsteps_rot, fs_side, length, m_dt)) return false;
 
     Guard guard(m_mutex);
-    gg_is_walking = true; // TODO: 自動でgg_is_walkingをfalseにする & constraintsのclear
+    gg->setWalkingState(true);
 
     return true;
 }

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -365,6 +365,7 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onExecute(RTC::UniqueId ec_id)
     gg->setCurrentLoop(loop);
     readInportData();
     updateBodyParams();
+    if(!gg_is_walking) gg->setConstraintToFootCoord(m_robot);
 
     gg->setDebugLevel(m_debugLevel);
 

--- a/rtc/AutoBalanceStabilizer/COGTrajectoryGenerator.cpp
+++ b/rtc/AutoBalanceStabilizer/COGTrajectoryGenerator.cpp
@@ -667,7 +667,10 @@ hrp::Vector3 COGTrajectoryGenerator::calcFootGuidedCogWalk(const std::vector<Con
     if (landing_idx == cur_const_idx) {
         constexpr double PREVIEW_TIME = 1.6;
         if (ref_zmp_goals[cur_zmp_idx + 1].second > cur_count) step_remain_time = const_remain_time;
-        else step_remain_time = const_remain_time = PREVIEW_TIME;
+        else {
+            step_remain_time = const_remain_time = PREVIEW_TIME;
+            is_walking = false;
+        }
     }
 
     const size_t zmp_goals_size = ref_zmp_goals.size();

--- a/rtc/AutoBalanceStabilizer/COGTrajectoryGenerator.h
+++ b/rtc/AutoBalanceStabilizer/COGTrajectoryGenerator.h
@@ -48,6 +48,8 @@ class COGTrajectoryGenerator
     CogCalculationType calculation_type = PREVIEW_CONTROL;
     std::unique_ptr<ExtendedPreviewController> preview_controller;
 
+    bool is_walking = false;
+
     void updateCogState(const hrp::Vector3& input_zmp, const double dt, const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION);
 
     // Foot guided run variables
@@ -79,6 +81,8 @@ class COGTrajectoryGenerator
     const double& getStepRemainTime() const { return step_remain_time; }
     const double& getConstRemainTime() const { return const_remain_time; }
     const double getRefCogZ() const { return ref_cog_z; }
+    const bool getWalkingState() { return is_walking; };
+    void setWalkingState(const bool _walking) { is_walking = _walking; };
     hrp::Vector3 calcCP(const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION) const { return cog + cog_vel / omega; }
     hrp::Vector3 calcPointMassZMP(const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION) const
     {

--- a/rtc/AutoBalanceStabilizer/GaitGenerator.cpp
+++ b/rtc/AutoBalanceStabilizer/GaitGenerator.cpp
@@ -1363,4 +1363,14 @@ bool GaitGenerator::startJumping(const double dt, const double g_acc)
     std::cerr << "add jump end" << std::endl;
 }
 
+void GaitGenerator::setConstraintToFootCoord(const hrp::BodyPtr& _robot)
+{
+    auto& cur_constraints = constraints_list.back().constraints;
+    for (auto& constraint : cur_constraints) {
+        const hrp::Link* const link = _robot->link(constraint.getLinkId());
+        constraint.targetPos() = constraint.calcActualTargetPosFromLinkState(link->p, link->R);
+        constraint.targetRot() = constraint.calcActualTargetRotFromLinkState(link->R);
+    }
+}
+
 }

--- a/rtc/AutoBalanceStabilizer/GaitGenerator.h
+++ b/rtc/AutoBalanceStabilizer/GaitGenerator.h
@@ -165,6 +165,9 @@ class GaitGenerator
     const hrp::Vector3& getNewRefCP() const { return cog_gen->getNewRefCP(); }
     const double& getStepRemainTime() const { return cog_gen->getStepRemainTime(); }
     const double& getConstRemainTime() const { return cog_gen->getConstRemainTime(); }
+    const bool getWalkingState() { return cog_gen->getWalkingState(); };
+
+    void setWalkingState(const bool _walking) { cog_gen->setWalkingState(_walking); };
 
     // Todo: Private ?
     hrp::Vector3 calcReferenceCOPFromModel(const hrp::BodyPtr& _robot, const std::vector<LinkConstraint>& cur_consts) const;

--- a/rtc/AutoBalanceStabilizer/GaitGenerator.h
+++ b/rtc/AutoBalanceStabilizer/GaitGenerator.h
@@ -331,6 +331,8 @@ class GaitGenerator
     bool startJumping(const double dt, const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION);
     bool startRunJumpDemo(const double dt, const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION);
 
+    void setConstraintToFootCoord(const hrp::BodyPtr& _robot);
+
     // gopos: 接触のCycleを記述したい
     // void goPos(const rats::coordinates& target, const size_t one_step_count,
     //            const double max_step_length, const double max_rotate_angle,


### PR DESCRIPTION
stateEstimatorの変更が大きくなりそうなので一旦直接関係ないものをPRします．

https://github.com/kindsenior/rtmros_tutorials/pull/1
こちらはバグです．

本PRはバグフィックスではないですが，参照ZMP高さはなるべく着地高さと一致しているほうが制御性がよくなるらしいのであわせるようにしました．
is_walkigの切り替えはPREVIEW_CONTROLは対応してません（静止時はFOOT_GUIDED_WALKが呼ばれてる想定）
