### PR TITLE
reconfigure AutoBalanceStabilizer data port

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -335,7 +335,7 @@ class HrpsysConfigurator(object):
             if self.abc:
                 connectPorts(self.abc.port("basePoseOut"), self.rh.port("basePoseRef"))
             elif self.abst:
-                connectPorts(self.abst.port("basePoseOut"), self.rh.port("basePoseRef"))
+                connectPorts(self.abst.port("genBasePose"), self.rh.port("basePoseRef"))
             else:
                 connectPorts(self.sh.port("basePoseOut"), self.rh.port("basePoseRef"))
 
@@ -420,19 +420,19 @@ class HrpsysConfigurator(object):
         # connection for AutoBalanceStabilizer
         if rtm.findPort(self.rh.ref, "lfsensor") and \
            rtm.findPort(self.rh.ref, "rfsensor") and self.abst:
-            connectPorts(self.sh.port("basePosOut"),           self.abst.port("basePosIn"))
-            connectPorts(self.sh.port("baseRpyOut"),           self.abst.port("baseRpyIn"))
-            connectPorts(self.sh.port("zmpOut"),               self.abst.port("refZmpIn"))
-            connectPorts(self.sh.port("optionalDataOut"),      self.abst.port("optionalData"))
-            connectPorts(self.rh.port("q"),                    self.abst.port("qCurrent"))
-            connectPorts(self.kf.port("rpy"),                  self.abst.port("rpy"))
-            connectPorts(self.abst.port("accRef"),             self.kf.port("accRef"))
-            connectPorts(self.abst.port("tau"),                self.rh.port("tauRef"))
-            connectPorts(self.abst.port("pgain"),              self.rh.port("pgain"))
-            connectPorts(self.abst.port("dgain"),              self.rh.port("dgain"))
-            connectPorts(self.abst.port("tqpgain"),            self.rh.port("tqpgain"))
-            # connectPorts(self.abst.port("tqdgain"),            self.rh.port("tqdgain"))
-            connectPorts(self.abst.port("gainTransitionTime"), self.rh.port("gainTransitionTime"))
+            connectPorts(self.sh.port("basePosOut"),              self.abst.port("comBasePos"))
+            connectPorts(self.sh.port("baseRpyOut"),              self.abst.port("comBaseRpy"))
+            connectPorts(self.sh.port("zmpOut"),                  self.abst.port("comZmp"))
+            connectPorts(self.sh.port("optionalDataOut"),         self.abst.port("comOptionalData"))
+            connectPorts(self.rh.port("q"),                       self.abst.port("qAct"))
+            connectPorts(self.kf.port("rpy"),                     self.abst.port("actImuRpy"))
+            connectPorts(self.abst.port("ikImuAcc"),              self.kf.port("accRef"))
+            connectPorts(self.abst.port("modTau"),                self.rh.port("tauRef"))
+            connectPorts(self.abst.port("modPgain"),              self.rh.port("pgain"))
+            connectPorts(self.abst.port("modDgain"),              self.rh.port("dgain"))
+            connectPorts(self.abst.port("modTqPgain"),            self.rh.port("tqpgain"))
+            # connectPorts(self.abst.port("modTqDgain"),            self.rh.port("tqdgain"))
+            connectPorts(self.abst.port("modGainTransitionTime"), self.rh.port("gainTransitionTime"))
             if self.es:
                 connectPorts(self.abst.port("emergencySignal"), self.es.port("emergencySignal"))
 
@@ -605,7 +605,7 @@ class HrpsysConfigurator(object):
             if self.abc:
                 connectPorts(self.abc.port("basePosOut"), self.acf.port("posIn"))
             if self.abst:
-                connectPorts(self.abst.port("basePosOut"), self.acf.port("posIn"))
+                connectPorts(self.abst.port("genBasePos"), self.acf.port("posIn"))
 
     def activateComps(self):
         '''!@brief
@@ -964,29 +964,29 @@ class HrpsysConfigurator(object):
             self.connectLoggerPort(self.octd, "octdData")
         if self.abst != None:
             self.connectLoggerPort(self.abst, 'q')
-            self.connectLoggerPort(self.abst, 'tau')
-            self.connectLoggerPort(self.abst, 'refZmpOut')
-            self.connectLoggerPort(self.abst, 'nominalZmpOut')
-            self.connectLoggerPort(self.abst, 'refEndCpOut')
-            self.connectLoggerPort(self.abst, 'newRefCpOut')
-            self.connectLoggerPort(self.abst, 'remainTimeOut')
-            self.connectLoggerPort(self.abst, 'baseOriginRefZmp')
-            self.connectLoggerPort(self.abst, 'refCogOut')
-            self.connectLoggerPort(self.abst, 'refCogVelOut')
-            self.connectLoggerPort(self.abst, 'refCogAccOut')
-            self.connectLoggerPort(self.abst, 'refAngularMomentumRPY')
-            self.connectLoggerPort(self.abst, 'sbpCogOffset')
-            self.connectLoggerPort(self.abst, 'baseTformOut')
+            self.connectLoggerPort(self.abst, 'genBaseTform')
+            self.connectLoggerPort(self.abst, 'genZmp')
+            self.connectLoggerPort(self.abst, 'nominalZmp')
+            self.connectLoggerPort(self.abst, 'genEndCp')
+            self.connectLoggerPort(self.abst, 'genCp')
+            self.connectLoggerPort(self.abst, 'genRemainTime')
+            self.connectLoggerPort(self.abst, 'baseFrameGenZmp')
+            self.connectLoggerPort(self.abst, 'genCog')
+            self.connectLoggerPort(self.abst, 'genCogVel')
+            self.connectLoggerPort(self.abst, 'genCogAcc')
+            self.connectLoggerPort(self.abst, 'genAngularMomentumRpy')
+            self.connectLoggerPort(self.abst, 'genSbpCogOffset')
+            self.connectLoggerPort(self.abst, 'genContactStates')
+            self.connectLoggerPort(self.abst, 'modTau')
             self.connectLoggerPort(self.abst, 'actBaseRpy')
-            self.connectLoggerPort(self.abst, 'baseOriginActZmp')
-            self.connectLoggerPort(self.abst, 'originRefZmp')
-            self.connectLoggerPort(self.abst, 'originNewRefZmp')
-            self.connectLoggerPort(self.abst, 'originActZmp')
-            self.connectLoggerPort(self.abst, 'refContactStates')
+            self.connectLoggerPort(self.abst, 'baseFrameActZmp')
+            self.connectLoggerPort(self.abst, 'footFrameGenZmp')
+            self.connectLoggerPort(self.abst, 'footFrameModZmp')
+            self.connectLoggerPort(self.abst, 'footFrameActZmp')
             self.connectLoggerPort(self.abst, 'actContactStates')
-            self.connectLoggerPort(self.abst, 'newRefWrenches')
-            self.connectLoggerPort(self.abst, 'footOriginRefCog')
-            self.connectLoggerPort(self.abst, 'footOriginActCog')
+            self.connectLoggerPort(self.abst, 'modWrenches')
+            self.connectLoggerPort(self.abst, 'footFrameGenCog')
+            self.connectLoggerPort(self.abst, 'footFrameActCog')
 
         self.log_svc.clear()
         ## parallel running log process (outside from rtcd) for saving logs by emergency signal

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -435,10 +435,6 @@ class HrpsysConfigurator(object):
             connectPorts(self.abst.port("gainTransitionTime"), self.rh.port("gainTransitionTime"))
             if self.es:
                 connectPorts(self.abst.port("emergencySignal"), self.es.port("emergencySignal"))
-            if self.rfu:
-                connectPorts(self.abst.port("diffFootOriginExtMoment"),          self.rfu.port("diffFootOriginExtMoment"))
-                connectPorts(self.rfu.port("refFootOriginExtMoment"),            self.abst.port("refFootOriginExtMoment"))
-                connectPorts(self.rfu.port("refFootOriginExtMomentIsHoldValue"), self.abst.port("refFootOriginExtMomentIsHoldValue"))
 
         # ref force moment connection
         for sen in self.getForceSensorNames():

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -977,7 +977,6 @@ class HrpsysConfigurator(object):
             self.connectLoggerPort(self.abst, 'refAngularMomentumRPY')
             self.connectLoggerPort(self.abst, 'sbpCogOffset')
             self.connectLoggerPort(self.abst, 'baseTformOut')
-            self.connectLoggerPort(self.abst, 'controlSwingSupportTime')
             self.connectLoggerPort(self.abst, 'actBaseRpy')
             self.connectLoggerPort(self.abst, 'baseOriginActZmp')
             self.connectLoggerPort(self.abst, 'originRefZmp')

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -987,7 +987,6 @@ class HrpsysConfigurator(object):
             self.connectLoggerPort(self.abst, 'newRefWrenches')
             self.connectLoggerPort(self.abst, 'footOriginRefCog')
             self.connectLoggerPort(self.abst, 'footOriginActCog')
-            self.connectLoggerPort(self.abst, 'refCapturePoint')
 
         self.log_svc.clear()
         ## parallel running log process (outside from rtcd) for saving logs by emergency signal

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -70,8 +70,6 @@ AutoBalanceStabilizer::AutoBalanceStabilizer(RTC::Manager* manager)
       m_baseRpyIn("baseRpyIn", m_baseRpy),
       m_refZmpIn("refZmpIn", m_refZmp),
       m_optionalDataIn("optionalData", m_optionalData),
-      m_refFootOriginExtMomentIn("refFootOriginExtMoment", m_refFootOriginExtMoment),
-      m_refFootOriginExtMomentIsHoldValueIn("refFootOriginExtMomentIsHoldValue", m_refFootOriginExtMomentIsHoldValue),
 
       m_qOut("q", m_qRef),
       m_tauOut("tau", m_tau),
@@ -79,7 +77,6 @@ AutoBalanceStabilizer::AutoBalanceStabilizer(RTC::Manager* manager)
       m_baseRpyOut("baseRpyOut", m_baseRpy),
       m_basePoseOut("basePoseOut", m_basePose),
       m_accRefOut("accRef", m_accRef),
-      m_diffFootOriginExtMomentOut("diffFootOriginExtMoment", m_diffFootOriginExtMoment),
       m_emergencySignalOut("emergencySignal", m_emergencySignal),
       m_pgainOut("pgain", m_pgain),
       m_dgainOut("dgain", m_dgain),
@@ -532,8 +529,6 @@ void AutoBalanceStabilizer::setupBasicPort()
     addInPort("baseRpyIn", m_baseRpyIn);
     addInPort("refZmpIn", m_refZmpIn);
     addInPort("optionalData", m_optionalDataIn);
-    addInPort("refFootOriginExtMoment", m_refFootOriginExtMomentIn);
-    addInPort("refFootOriginExtMomentIsHoldValue", m_refFootOriginExtMomentIsHoldValueIn);
 
     // Set OutPort buffer
     addOutPort("q", m_qOut);
@@ -542,7 +537,6 @@ void AutoBalanceStabilizer::setupBasicPort()
     addOutPort("baseRpyOut", m_baseRpyOut);
     addOutPort("basePoseOut", m_basePoseOut);
     addOutPort("accRef", m_accRefOut);
-    addOutPort("diffStaticBalancePointOffset", m_diffFootOriginExtMomentOut);
     addOutPort("emergencySignal", m_emergencySignalOut);
     addOutPort("pgain", m_pgainOut);
     addOutPort("dgain", m_dgainOut);
@@ -664,18 +658,6 @@ void AutoBalanceStabilizer::readInportData()
     }
 
     if (m_optionalDataIn.isNew()) m_optionalDataIn.read(); // TODO
-
-    if (m_refFootOriginExtMomentIn.isNew()) {
-        m_refFootOriginExtMomentIn.read();
-        ref_foot_origin_ext_moment[0] = m_refFootOriginExtMoment.data.x;
-        ref_foot_origin_ext_moment[1] = m_refFootOriginExtMoment.data.y;
-        ref_foot_origin_ext_moment[2] = m_refFootOriginExtMoment.data.z;
-    }
-
-    if (m_refFootOriginExtMomentIsHoldValueIn.isNew()) {
-        m_refFootOriginExtMomentIsHoldValueIn.read();
-        is_ref_foot_origin_ext_moment_hold_value = m_refFootOriginExtMomentIsHoldValue.data;
-    }
 }
 
 void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
@@ -910,13 +892,6 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
         m_emergencySignal.data = emergency_signal_pair.second;
         m_emergencySignalOut.write();
     }
-
-    m_diffFootOriginExtMoment.tm = m_qRef.tm;
-    const hrp::Vector3 diff_foot_origin_ext_moment = st->getDiffFootOriginExtMoment();
-    m_diffFootOriginExtMoment.data.x = diff_foot_origin_ext_moment[0];
-    m_diffFootOriginExtMoment.data.y = diff_foot_origin_ext_moment[1];
-    m_diffFootOriginExtMoment.data.z = diff_foot_origin_ext_moment[2];
-    m_diffFootOriginExtMomentOut.write();
 
     m_actCP.tm = m_qRef.tm;
     const hrp::Vector3 rel_act_cp = st->getOriginActCP();

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -97,7 +97,6 @@ AutoBalanceStabilizer::AutoBalanceStabilizer(RTC::Manager* manager)
       m_refCogVelOut("refCogVelOut", m_refCogVel),
       m_refCogAccOut("refCogAccOut", m_refCogAcc),
       m_refAngularMomentumRPYOut("refAngularMomentumRPY", m_refAngularMomentumRPY),
-      m_controlSwingSupportTimeOut("controlSwingSupportTime", m_controlSwingSupportTime),
       m_sbpCogOffsetOut("sbpCogOffset", m_sbpCogOffset),
 
       // Data from Stabilizer
@@ -317,7 +316,6 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onInitialize()
 
         // Debug
         m_refContactStates.data.length(2);
-        m_controlSwingSupportTime.data.length(3 * 2);
     }
 
     storeRobotStatesForIK();
@@ -557,7 +555,6 @@ void AutoBalanceStabilizer::setupBasicPort()
     addOutPort("refCogVelOut", m_refCogVelOut);
     addOutPort("refCogAccOut", m_refCogAccOut);
     addOutPort("refAngularMomentumRPYOut", m_refAngularMomentumRPYOut);
-    addOutPort("controlSwingSupportTime", m_controlSwingSupportTimeOut);
     addOutPort("sbpCogOffset", m_sbpCogOffsetOut);
     // Data from Stabilizer
     addOutPort("actBaseRpy", m_actBaseRpyOut);
@@ -815,14 +812,6 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
         }
         m_refContactStatesOut.write();
     }
-
-    m_controlSwingSupportTime.tm = m_qRef.tm;
-    for (size_t i = 0; i < 2; ++i) {
-        for (size_t j = 0; j < 3; ++j) {
-            m_controlSwingSupportTime.data[3 * i + j] = ik_constraints[i].targetPos[j];
-        }
-    }
-    m_controlSwingSupportTimeOut.write();
 
     // Data from Stabilizer
     m_actBaseRpy.tm     = m_qRef.tm;

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -63,56 +63,56 @@ std::ostream& operator<<(std::ostream& os, const struct RTC::Time &tm)
 AutoBalanceStabilizer::AutoBalanceStabilizer(RTC::Manager* manager)
     : RTC::DataFlowComponentBase(manager),
       // <rtc-template block="initializer">
-      m_qCurrentIn("qCurrent", m_qCurrent),
+      m_qActIn("qAct", m_qAct),
       m_qRefIn("qRef", m_qRef),
-      m_rpyIn("rpy", m_rpy), // from KF
-      m_basePosIn("basePosIn", m_basePos),
-      m_baseRpyIn("baseRpyIn", m_baseRpy),
-      m_refZmpIn("refZmpIn", m_refZmp),
-      m_optionalDataIn("optionalData", m_optionalData),
+      m_actImuRpyIn("actImuRpy", m_actImuRpy), // from KF
+      m_comBasePosIn("comBasePos", m_comBasePos),
+      m_comBaseRpyIn("comBaseRpy", m_comBaseRpy),
+      m_comZmpIn("comZmp", m_comZmp),
+      m_comOptionalDataIn("comOptionalData", m_comOptionalData),
 
       m_qOut("q", m_qRef),
-      m_tauOut("tau", m_tau),
-      m_basePosOut("basePosOut", m_basePos),
-      m_baseRpyOut("baseRpyOut", m_baseRpy),
-      m_basePoseOut("basePoseOut", m_basePose),
-      m_accRefOut("accRef", m_accRef),
+      m_genBasePosOut("genBasePos", m_genBasePos),
+      m_genBaseRpyOut("genBaseRpy", m_genBaseRpy),
+      m_genBasePoseOut("genBasePose", m_genBasePose),
+      m_ikImuAccOut("ikImuAcc", m_ikImuAcc),
       m_emergencySignalOut("emergencySignal", m_emergencySignal),
-      m_pgainOut("pgain", m_pgain),
-      m_dgainOut("dgain", m_dgain),
-      m_tqpgainOut("tqpgain", m_tqpgain),
-      // m_dgainOut("tqdgain", m_tqdgain),
-      m_gainTransitionTimeOut("gainTransitionTime", m_gainTransitionTime),
 
       // Out port for debugging
-      m_refZmpOut("refZmpOut", m_refZmp), // global
-      m_nominalZmpOut("nominalZmpOut", m_nominalZmp), // global
-      m_refEndCpOut("refEndCpOut", m_refEndCp), // global
-      m_newRefCpOut("newRefCpOut", m_newRefCp), // global
-      m_remainTimeOut("remainTimeOut", m_remainTime),
-      m_refCmpOut("refCmpOut", m_refCmp),
-      m_baseOriginRefZmpOut("baseOriginRefZmp", m_baseOriginRefZmp),
-      m_baseTformOut("baseTformOut", m_baseTform),
-      m_refCogOut("refCogOut", m_refCog),
-      m_refCogVelOut("refCogVelOut", m_refCogVel),
-      m_refCogAccOut("refCogAccOut", m_refCogAcc),
-      m_refAngularMomentumRPYOut("refAngularMomentumRPY", m_refAngularMomentumRPY),
-      m_sbpCogOffsetOut("sbpCogOffset", m_sbpCogOffset),
+      m_genBaseTformOut("genBaseTform", m_genBaseTform),
+      m_genZmpOut("genZmp", m_genZmp), // global
+      m_nominalZmpOut("nominalZmp", m_nominalZmp), // global
+      m_genEndCpOut("genEndCp", m_genEndCp), // global
+      m_genCpOut("genCp", m_genCp), // global
+      m_genRemainTimeOut("genRemainTime", m_genRemainTime),
+      m_genCmpOut("genCmp", m_genCmp),
+      m_baseFrameGenZmpOut("baseFrameGenZmp", m_baseFrameGenZmp),
+      m_genCogOut("genCog", m_genCog),
+      m_genCogVelOut("genCogVel", m_genCogVel),
+      m_genCogAccOut("genCogAcc", m_genCogAcc),
+      m_genAngularMomentumRpyOut("genAngularMomentumRpy", m_genAngularMomentumRpy),
+      m_genSbpCogOffsetOut("genSbpCogOffset", m_genSbpCogOffset),
+      m_genContactStatesOut("genContactStates", m_genContactStates),
 
       // Data from Stabilizer
+      m_modTauOut("modTau", m_modTau),
       m_actBaseRpyOut("actBaseRpy", m_actBaseRpy),
-      m_baseOriginActZmpOut("baseOriginActZmp", m_baseOriginActZmp),
-      m_originRefZmpOut("originRefZmp", m_originRefZmp),
-      m_originNewRefZmpOut("originNewRefZmp", m_originNewRefZmp),
-      m_originActZmpOut("originActZmp", m_originActZmp),
-      m_footOriginRefCogOut("footOriginRefCog", m_footOriginRefCog),
-      m_footOriginActCogOut("footOriginActCog", m_footOriginActCog),
-      m_refContactStatesOut("refContactStates", m_refContactStates),
+      m_baseFrameActZmpOut("baseFrameActZmp", m_baseFrameActZmp),
+      m_footFrameGenZmpOut("footFrameGenZmp", m_footFrameGenZmp),
+      m_footFrameModZmpOut("footFrameModZmp", m_footFrameModZmp),
+      m_footFrameActZmpOut("footFrameActZmp", m_footFrameActZmp),
+      m_footFrameGenCogOut("footFrameGenCog", m_footFrameGenCog),
+      m_footFrameActCogOut("footFrameActCog", m_footFrameActCog),
       m_actContactStatesOut("actContactStates", m_actContactStates),
-      m_newRefWrenchesOut("newRefWrenches", m_newRefWrenches),
-      m_refCPOut("refCapturePoint", m_refCP),
-      m_actCPOut("actCapturePoint", m_actCP),
-      m_COPInfoOut("COPInfo", m_COPInfo),
+      m_modWrenchesOut("modWrenches", m_modWrenches),
+      m_baseFrameGenCpOut("baseFrameGenCp", m_baseFrameGenCp),
+      m_baseFrameActCpOut("baseFrameActCp", m_baseFrameActCp),
+      m_eeOriginCopInfoOut("eeOriginCopInfo", m_eeOriginCopInfo),
+      m_modPgainOut("modPgain", m_modPgain),
+      m_modDgainOut("modDgain", m_modDgain),
+      m_modTqPgainOut("modTqPgain", m_modTqPgain),
+      // m_modTqDgainOut("modTqDgain", m_modTqDgain),
+      m_modGainTransitionTimeOut("modGainTransitionTime", m_modGainTransitionTime),
 
       m_AutoBalanceStabilizerServicePort("AutoBalanceStabilizerService")
       // </rtc-template>
@@ -207,17 +207,17 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onInitialize()
         }
 
         m_actContactStates.data.length(ee_num);
-        m_newRefWrenches.data.length(ee_num * 6);
-        m_COPInfo.data.length(ee_num * 3);
+        m_modWrenches.data.length(ee_num * 6);
+        m_eeOriginCopInfo.data.length(ee_num * 3);
         for (size_t i = 0; i < ee_num; i++) {
             m_actContactStates.data[i] = false;
 
             for (size_t j = 0; j < 6; ++j) {
-                m_newRefWrenches.data[6*i+j] = 0.0;
+                m_modWrenches.data[6*i+j] = 0.0;
             }
 
             for (size_t j = 0; j < 3; ++j) {
-                m_COPInfo.data[i * 3 + j] = 0.0;
+                m_eeOriginCopInfo.data[i * 3 + j] = 0.0;
             }
         }
 
@@ -281,7 +281,7 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onInitialize()
         registerInPort(sensor_names[i].c_str(), *m_wrenchesIn[i]);
     }
 
-    m_accRef.data.ax = m_accRef.data.ay = m_accRef.data.az = 0.0;
+    m_ikImuAcc.data.ax = m_ikImuAcc.data.ay = m_ikImuAcc.data.az = 0.0;
 
     {
         const hrp::Sensor* const gyro = m_robot->sensor<hrp::RateGyroSensor>("gyrometer");
@@ -295,11 +295,11 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onInitialize()
     // allocate memory
     {
         const size_t num_joints = m_robot->numJoints();
-        m_qCurrent.data.length(num_joints);
+        m_qAct.data.length(num_joints);
         m_qRef.data.length(num_joints);
-        m_tau.data.length(num_joints);
-        m_baseTform.data.length(12);
-        m_remainTime.data.length(2);
+        m_modTau.data.length(num_joints);
+        m_genBaseTform.data.length(12);
+        m_genRemainTime.data.length(2);
 
         q_prev_ik = hrp::dvector::Zero(num_joints);
         q_act = hrp::dvector::Zero(num_joints);
@@ -308,14 +308,14 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onInitialize()
         ref_wrenches_for_st.resize(num_fsensors, hrp::dvector6::Zero());
         act_wrenches.resize(num_fsensors, hrp::dvector6::Zero());
 
-        m_pgain.data.length(num_joints);
-        m_dgain.data.length(num_joints);
-        m_tqpgain.data.length(num_joints);
-        // m_tqdgain.data.length(num_joints);
-        m_gainTransitionTime.data.length(num_joints);
+        m_modPgain.data.length(num_joints);
+        m_modDgain.data.length(num_joints);
+        m_modTqPgain.data.length(num_joints);
+        // m_modTqDgain.data.length(num_joints);
+        m_modGainTransitionTime.data.length(num_joints);
 
         // Debug
-        m_refContactStates.data.length(2);
+        m_genContactStates.data.length(2);
     }
 
     storeRobotStatesForIK();
@@ -520,56 +520,56 @@ void AutoBalanceStabilizer::setupBasicPort()
     // Registration: InPort/OutPort/Service
     // <rtc-template block="registration">
     // Set InPort buffers
-    addInPort("qCurrent", m_qCurrentIn);
+    addInPort("qAct", m_qActIn);
     addInPort("qRef", m_qRefIn);
-    addInPort("rpy", m_rpyIn);
-    addInPort("basePosIn", m_basePosIn);
-    addInPort("baseRpyIn", m_baseRpyIn);
-    addInPort("refZmpIn", m_refZmpIn);
-    addInPort("optionalData", m_optionalDataIn);
+    addInPort("actImuRpy", m_actImuRpyIn);
+    addInPort("comBasePos", m_comBasePosIn);
+    addInPort("comBaseRpy", m_comBaseRpyIn);
+    addInPort("comZmp", m_comZmpIn);
+    addInPort("comOptionalData", m_comOptionalDataIn);
 
     // Set OutPort buffer
     addOutPort("q", m_qOut);
-    addOutPort("tau", m_tauOut);
-    addOutPort("basePosOut", m_basePosOut);
-    addOutPort("baseRpyOut", m_baseRpyOut);
-    addOutPort("basePoseOut", m_basePoseOut);
-    addOutPort("accRef", m_accRefOut);
+    addOutPort("genBasePos", m_genBasePosOut);
+    addOutPort("genBaseRpy", m_genBaseRpyOut);
+    addOutPort("genBasePose", m_genBasePoseOut);
+    addOutPort("ikImuAcc", m_ikImuAccOut);
     addOutPort("emergencySignal", m_emergencySignalOut);
-    addOutPort("pgain", m_pgainOut);
-    addOutPort("dgain", m_dgainOut);
-    addOutPort("tqpgain", m_tqpgainOut);
-    // addOutPort("tqdgain", m_tqdgainOut);
-    addOutPort("gainTransitionTime", m_gainTransitionTimeOut);
 
     // Out port for debugging
-    addOutPort("refZmpOut", m_refZmpOut);
-    addOutPort("nominalZmpOut", m_nominalZmpOut);
-    addOutPort("refEndCpOut", m_refEndCpOut);
-    addOutPort("newRefCpOut", m_newRefCpOut);
-    addOutPort("remainTimeOut", m_remainTimeOut);
-    addOutPort("refCmpOut", m_refCmpOut);
-    addOutPort("baseOriginRefZmp", m_baseOriginRefZmpOut);
-    addOutPort("baseTformOut", m_baseTformOut);
-    addOutPort("refCogOut", m_refCogOut);
-    addOutPort("refCogVelOut", m_refCogVelOut);
-    addOutPort("refCogAccOut", m_refCogAccOut);
-    addOutPort("refAngularMomentumRPYOut", m_refAngularMomentumRPYOut);
-    addOutPort("sbpCogOffset", m_sbpCogOffsetOut);
+    addOutPort("genZmp", m_genZmpOut);
+    addOutPort("nominalZmp", m_nominalZmpOut);
+    addOutPort("genEndCp", m_genEndCpOut);
+    addOutPort("genCp", m_genCpOut);
+    addOutPort("genRemainTime", m_genRemainTimeOut);
+    addOutPort("genCmp", m_genCmpOut);
+    addOutPort("baseFrameGenZmp", m_baseFrameGenZmpOut);
+    addOutPort("genBaseTform", m_genBaseTformOut);
+    addOutPort("genCog", m_genCogOut);
+    addOutPort("genCogVel", m_genCogVelOut);
+    addOutPort("genCogAcc", m_genCogAccOut);
+    addOutPort("genAngularMomentumRpy", m_genAngularMomentumRpyOut);
+    addOutPort("genSbpCogOffset", m_genSbpCogOffsetOut);
+    addOutPort("baseFrameGenCp", m_baseFrameGenCpOut);
+    addOutPort("genContactStates", m_genContactStatesOut);
     // Data from Stabilizer
+    addOutPort("modTau", m_modTauOut);
     addOutPort("actBaseRpy", m_actBaseRpyOut);
-    addOutPort("baseOriginActZmp", m_baseOriginActZmpOut);
-    addOutPort("originRefZmp", m_originRefZmpOut);
-    addOutPort("originNewRefZmp", m_originNewRefZmpOut);
-    addOutPort("originActZmp", m_originActZmpOut);
-    addOutPort("footOriginRefCog", m_footOriginRefCogOut);
-    addOutPort("footOriginActCog", m_footOriginActCogOut);
-    addOutPort("refContactStates", m_refContactStatesOut);
+    addOutPort("baseFrameActZmp", m_baseFrameActZmpOut);
+    addOutPort("footFrameGenZmp", m_footFrameGenZmpOut);
+    addOutPort("footFrameModZmp", m_footFrameModZmpOut);
+    addOutPort("footFrameActZmp", m_footFrameActZmpOut);
+    addOutPort("footFrameGenCog", m_footFrameGenCogOut);
+    addOutPort("footFrameActCog", m_footFrameActCogOut);
     addOutPort("actContactStates", m_actContactStatesOut);
-    addOutPort("newRefWrenches", m_newRefWrenchesOut);
-    addOutPort("refCapturePoint", m_refCPOut);
-    addOutPort("actCapturePoint", m_actCPOut);
-    addOutPort("COPInfo", m_COPInfoOut);
+    addOutPort("modWrenches", m_modWrenchesOut);
+    addOutPort("baseFrameActCp", m_baseFrameActCpOut);
+    addOutPort("eeOriginCopInfo", m_eeOriginCopInfoOut);
+    addOutPort("modPgain", m_modPgainOut);
+    addOutPort("modDgain", m_modDgainOut);
+    addOutPort("modTqPgain", m_modTqPgainOut);
+    // addOutPort("modTqDgain", m_modTqDgainOut);
+    addOutPort("modGainTransitionTime", m_modGainTransitionTimeOut);
 
     // Set service provider to Ports
     m_AutoBalanceStabilizerServicePort.registerProvider("service0", "AutoBalanceStabilizerService", m_service0);
@@ -587,10 +587,10 @@ void AutoBalanceStabilizer::setupBasicPort()
 
 void AutoBalanceStabilizer::readInportData()
 {
-    if (m_qCurrentIn.isNew()) {
-        m_qCurrentIn.read();
+    if (m_qActIn.isNew()) {
+        m_qActIn.read();
         for (size_t i = 0; i < m_robot->numJoints(); ++i) {
-            q_act[i] = m_qCurrent.data[i];
+            q_act[i] = m_qAct.data[i];
         }
     }
 
@@ -601,30 +601,30 @@ void AutoBalanceStabilizer::readInportData()
         }
     }
 
-    if (m_rpyIn.isNew()) {
-        m_rpyIn.read();
-        act_rpy[0] = m_rpy.data.r;
-        act_rpy[1] = m_rpy.data.p;
-        act_rpy[2] = m_rpy.data.y;
+    if (m_actImuRpyIn.isNew()) {
+        m_actImuRpyIn.read();
+        act_rpy[0] = m_actImuRpy.data.r;
+        act_rpy[1] = m_actImuRpy.data.p;
+        act_rpy[2] = m_actImuRpy.data.y;
     }
 
-    if (m_basePosIn.isNew()) {
-        m_basePosIn.read();
-        ref_base_pos(0) = m_basePos.data.x;
-        ref_base_pos(1) = m_basePos.data.y;
-        ref_base_pos(2) = m_basePos.data.z;
+    if (m_comBasePosIn.isNew()) {
+        m_comBasePosIn.read();
+        ref_base_pos(0) = m_comBasePos.data.x;
+        ref_base_pos(1) = m_comBasePos.data.y;
+        ref_base_pos(2) = m_comBasePos.data.z;
     }
 
-    if (m_baseRpyIn.isNew()) {
-        m_baseRpyIn.read();
-        ref_base_rot = hrp::rotFromRpy(m_baseRpy.data.r, m_baseRpy.data.p, m_baseRpy.data.y);
+    if (m_comBaseRpyIn.isNew()) {
+        m_comBaseRpyIn.read();
+        ref_base_rot = hrp::rotFromRpy(m_comBaseRpy.data.r, m_comBaseRpy.data.p, m_comBaseRpy.data.y);
     }
 
-    if (m_refZmpIn.isNew()) {
-        m_refZmpIn.read();
-        input_ref_zmp(0) = m_refZmp.data.x;
-        input_ref_zmp(1) = m_refZmp.data.y;
-        input_ref_zmp(2) = m_refZmp.data.z;
+    if (m_comZmpIn.isNew()) {
+        m_comZmpIn.read();
+        input_ref_zmp(0) = m_comZmp.data.x;
+        input_ref_zmp(1) = m_comZmp.data.y;
+        input_ref_zmp(2) = m_comZmp.data.z;
     }
 
     const size_t num_fsensors = m_wrenchesIn.size();
@@ -654,7 +654,7 @@ void AutoBalanceStabilizer::readInportData()
         }
     }
 
-    if (m_optionalDataIn.isNew()) m_optionalDataIn.read(); // TODO
+    if (m_comOptionalDataIn.isNew()) m_comOptionalDataIn.read(); // TODO
 }
 
 void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
@@ -678,49 +678,49 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
     const unsigned int qRef_length = m_qRef.data.length();
     for (unsigned int i = 0; i < qRef_length; i++) {
         m_qRef.data[i] = st_port_data.joint_angles(i);
-        m_tau.data[i]  = st_port_data.joint_torques(i);
+        m_modTau.data[i]  = st_port_data.joint_torques(i);
     }
-    m_tau.tm = m_qRef.tm;
+    m_modTau.tm = m_qRef.tm;
     if (qRef_length != 0) {
         m_qOut.write();
-        m_tauOut.write();
+        m_modTauOut.write();
     }
 
-    m_basePos.tm     = m_qRef.tm;
-    m_basePos.data.x = base_pos(0);
-    m_basePos.data.y = base_pos(1);
-    m_basePos.data.z = base_pos(2);
-    m_basePosOut.write();
+    m_genBasePos.tm     = m_qRef.tm;
+    m_genBasePos.data.x = base_pos(0);
+    m_genBasePos.data.y = base_pos(1);
+    m_genBasePos.data.z = base_pos(2);
+    m_genBasePosOut.write();
 
     const hrp::Vector3 base_rpy = hrp::rpyFromRot(base_rot);
-    m_baseRpy.tm     = m_qRef.tm;
-    m_baseRpy.data.r = base_rpy(0);
-    m_baseRpy.data.p = base_rpy(1);
-    m_baseRpy.data.y = base_rpy(2);
-    m_baseRpyOut.write();
+    m_genBaseRpy.tm     = m_qRef.tm;
+    m_genBaseRpy.data.r = base_rpy(0);
+    m_genBaseRpy.data.p = base_rpy(1);
+    m_genBaseRpy.data.y = base_rpy(2);
+    m_genBaseRpyOut.write();
 
-    double *tform_arr = m_baseTform.data.get_buffer();
-    m_baseTform.tm    = m_qRef.tm;
-    tform_arr[0]      = m_basePos.data.x;
-    tform_arr[1]      = m_basePos.data.y;
-    tform_arr[2]      = m_basePos.data.z;
+    double *tform_arr = m_genBaseTform.data.get_buffer();
+    m_genBaseTform.tm    = m_qRef.tm;
+    tform_arr[0]      = m_genBasePos.data.x;
+    tform_arr[1]      = m_genBasePos.data.y;
+    tform_arr[2]      = m_genBasePos.data.z;
     hrp::setMatrix33ToRowMajorArray(base_rot, tform_arr, 3);
-    m_baseTformOut.write();
+    m_genBaseTformOut.write();
 
-    m_basePose.tm                 = m_qRef.tm;
-    m_basePose.data.position.x    = m_basePos.data.x;
-    m_basePose.data.position.y    = m_basePos.data.y;
-    m_basePose.data.position.z    = m_basePos.data.z;
-    m_basePose.data.orientation.r = m_baseRpy.data.r;
-    m_basePose.data.orientation.p = m_baseRpy.data.p;
-    m_basePose.data.orientation.y = m_baseRpy.data.y;
-    m_basePoseOut.write();
+    m_genBasePose.tm                 = m_qRef.tm;
+    m_genBasePose.data.position.x    = m_genBasePos.data.x;
+    m_genBasePose.data.position.y    = m_genBasePos.data.y;
+    m_genBasePose.data.position.z    = m_genBasePos.data.z;
+    m_genBasePose.data.orientation.r = m_genBaseRpy.data.r;
+    m_genBasePose.data.orientation.p = m_genBaseRpy.data.p;
+    m_genBasePose.data.orientation.y = m_genBaseRpy.data.y;
+    m_genBasePoseOut.write();
 
-    m_refZmp.tm     = m_qRef.tm;
-    m_refZmp.data.x = ref_zmp_global(0);
-    m_refZmp.data.y = ref_zmp_global(1);
-    m_refZmp.data.z = ref_zmp_global(2);
-    m_refZmpOut.write();
+    m_genZmp.tm     = m_qRef.tm;
+    m_genZmp.data.x = ref_zmp_global(0);
+    m_genZmp.data.y = ref_zmp_global(1);
+    m_genZmp.data.z = ref_zmp_global(2);
+    m_genZmpOut.write();
 
     m_nominalZmp.tm     = m_qRef.tm;
     m_nominalZmp.data.x = nominal_zmp_global(0);
@@ -728,82 +728,82 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
     m_nominalZmp.data.z = nominal_zmp_global(2);
     m_nominalZmpOut.write();
 
-    m_refEndCp.tm     = m_qRef.tm;
-    m_refEndCp.data.x = ref_end_cp_global(0);
-    m_refEndCp.data.y = ref_end_cp_global(1);
-    m_refEndCp.data.z = ref_end_cp_global(2);
-    m_refEndCpOut.write();
+    m_genEndCp.tm     = m_qRef.tm;
+    m_genEndCp.data.x = ref_end_cp_global(0);
+    m_genEndCp.data.y = ref_end_cp_global(1);
+    m_genEndCp.data.z = ref_end_cp_global(2);
+    m_genEndCpOut.write();
 
-    m_newRefCp.tm     = m_qRef.tm;
-    m_newRefCp.data.x = new_ref_cp_global(0);
-    m_newRefCp.data.y = new_ref_cp_global(1);
-    m_newRefCp.data.z = new_ref_cp_global(2);
-    m_newRefCpOut.write();
+    m_genCp.tm     = m_qRef.tm;
+    m_genCp.data.x = new_ref_cp_global(0);
+    m_genCp.data.y = new_ref_cp_global(1);
+    m_genCp.data.z = new_ref_cp_global(2);
+    m_genCpOut.write();
 
-    m_remainTime.tm   = m_qRef.tm;
-    m_remainTime.data[0] = step_remain_time;
-    m_remainTime.data[1] = const_remain_time;
-    m_remainTimeOut.write();
+    m_genRemainTime.tm   = m_qRef.tm;
+    m_genRemainTime.data[0] = step_remain_time;
+    m_genRemainTime.data[1] = const_remain_time;
+    m_genRemainTimeOut.write();
 
-    m_baseOriginRefZmp.tm     = m_qRef.tm;
-    m_baseOriginRefZmp.data.x = ref_zmp_base_frame(0);
-    m_baseOriginRefZmp.data.y = ref_zmp_base_frame(1);
-    m_baseOriginRefZmp.data.z = ref_zmp_base_frame(2);
-    m_baseOriginRefZmpOut.write();
+    m_baseFrameGenZmp.tm     = m_qRef.tm;
+    m_baseFrameGenZmp.data.x = ref_zmp_base_frame(0);
+    m_baseFrameGenZmp.data.y = ref_zmp_base_frame(1);
+    m_baseFrameGenZmp.data.z = ref_zmp_base_frame(2);
+    m_baseFrameGenZmpOut.write();
 
-    // m_refCmp.tm     = m_qRef.tm;
-    // m_refCmp.data.x = ref_cmp(0);
-    // m_refCmp.data.y = ref_cmp(1);
-    // m_refCmp.data.z = ref_cmp(2);
-    // m_refCmpOut.write();
+    // m_genCmp.tm     = m_qRef.tm;
+    // m_genCmp.data.x = ref_cmp(0);
+    // m_genCmp.data.y = ref_cmp(1);
+    // m_genCmp.data.z = ref_cmp(2);
+    // m_genCmpOut.write();
 
-    m_refCog.tm     = m_qRef.tm;
-    m_refCog.data.x = ref_cog(0);
-    m_refCog.data.y = ref_cog(1);
-    m_refCog.data.z = ref_cog(2);
-    m_refCogOut.write();
+    m_genCog.tm     = m_qRef.tm;
+    m_genCog.data.x = ref_cog(0);
+    m_genCog.data.y = ref_cog(1);
+    m_genCog.data.z = ref_cog(2);
+    m_genCogOut.write();
 
-    m_refCogVel.tm     = m_qRef.tm;
-    m_refCogVel.data.x = ref_cog_vel(0);
-    m_refCogVel.data.y = ref_cog_vel(1);
-    m_refCogVel.data.z = ref_cog_vel(2);
-    m_refCogVelOut.write();
+    m_genCogVel.tm     = m_qRef.tm;
+    m_genCogVel.data.x = ref_cog_vel(0);
+    m_genCogVel.data.y = ref_cog_vel(1);
+    m_genCogVel.data.z = ref_cog_vel(2);
+    m_genCogVelOut.write();
 
-    m_refCogAcc.tm     = m_qRef.tm;
-    m_refCogAcc.data.x = ref_cog_acc(0);
-    m_refCogAcc.data.y = ref_cog_acc(1);
-    m_refCogAcc.data.z = ref_cog_acc(2);
-    m_refCogAccOut.write();
+    m_genCogAcc.tm     = m_qRef.tm;
+    m_genCogAcc.data.x = ref_cog_acc(0);
+    m_genCogAcc.data.y = ref_cog_acc(1);
+    m_genCogAcc.data.z = ref_cog_acc(2);
+    m_genCogAccOut.write();
 
     {
-        m_refAngularMomentumRPY.tm = m_qRef.tm;
+        m_genAngularMomentumRpy.tm = m_qRef.tm;
         const hrp::Vector3 ref_momentum_rpy = hrp::rpyFromRot(hrp::rotationMatrixFromOmega(ref_momentum));
-        m_refAngularMomentumRPY.data.x = ref_momentum_rpy(0);
-        m_refAngularMomentumRPY.data.y = ref_momentum_rpy(1);
-        m_refAngularMomentumRPY.data.z = ref_momentum_rpy(2);
-        m_refAngularMomentumRPYOut.write();
+        m_genAngularMomentumRpy.data.x = ref_momentum_rpy(0);
+        m_genAngularMomentumRpy.data.y = ref_momentum_rpy(1);
+        m_genAngularMomentumRpy.data.z = ref_momentum_rpy(2);
+        m_genAngularMomentumRpyOut.write();
     }
 
-    m_sbpCogOffset.tm = m_qRef.tm;
-    m_sbpCogOffset.data.x = sbp_cog_offset(0);
-    m_sbpCogOffset.data.y = sbp_cog_offset(1);
-    m_sbpCogOffset.data.z = sbp_cog_offset(2);
-    m_sbpCogOffsetOut.write();
+    m_genSbpCogOffset.tm = m_qRef.tm;
+    m_genSbpCogOffset.data.x = sbp_cog_offset(0);
+    m_genSbpCogOffset.data.y = sbp_cog_offset(1);
+    m_genSbpCogOffset.data.z = sbp_cog_offset(2);
+    m_genSbpCogOffsetOut.write();
 
-    m_accRef.data.ax = acc_ref(0);
-    m_accRef.data.ay = acc_ref(1);
-    m_accRef.data.az = acc_ref(2);
-    m_accRefOut.write();
+    m_ikImuAcc.data.ax = acc_ref(0);
+    m_ikImuAcc.data.ay = acc_ref(1);
+    m_ikImuAcc.data.az = acc_ref(2);
+    m_ikImuAccOut.write();
 
     // control parameters
     {
-        m_refContactStates.tm = m_qRef.tm;
+        m_genContactStates.tm = m_qRef.tm;
         const auto& cs = gg->getCurrentConstraints(loop);
-        for (size_t i = 0; i < m_refContactStates.data.length(); ++i) {
-            m_refContactStates.data[i] = cs.constraints[i].getConstraintType();
-            // m_refContactStates.data[i] = (cs.constraints[i].getConstraintType() == hrp::LinkConstraint::FIX);
+        for (size_t i = 0; i < m_genContactStates.data.length(); ++i) {
+            m_genContactStates.data[i] = cs.constraints[i].getConstraintType();
+            // m_genContactStates.data[i] = (cs.constraints[i].getConstraintType() == hrp::LinkConstraint::FIX);
         }
-        m_refContactStatesOut.write();
+        m_genContactStatesOut.write();
     }
 
     // Data from Stabilizer
@@ -813,41 +813,41 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
     m_actBaseRpy.data.y = st_port_data.act_base_rpy(2);
     m_actBaseRpyOut.write();
 
-    m_baseOriginActZmp.tm = m_qRef.tm;
-    m_baseOriginActZmp.data.x = st_port_data.rel_act_zmp(0);
-    m_baseOriginActZmp.data.y = st_port_data.rel_act_zmp(1);
-    m_baseOriginActZmp.data.z = st_port_data.rel_act_zmp(2);
-    m_baseOriginActZmpOut.write();
+    m_baseFrameActZmp.tm = m_qRef.tm;
+    m_baseFrameActZmp.data.x = st_port_data.rel_act_zmp(0);
+    m_baseFrameActZmp.data.y = st_port_data.rel_act_zmp(1);
+    m_baseFrameActZmp.data.z = st_port_data.rel_act_zmp(2);
+    m_baseFrameActZmpOut.write();
 
-    m_originRefZmp.tm = m_qRef.tm;
-    m_originRefZmp.data.x = st_port_data.ref_zmp(0);
-    m_originRefZmp.data.y = st_port_data.ref_zmp(1);
-    m_originRefZmp.data.z = st_port_data.ref_zmp(2);
-    m_originRefZmpOut.write();
+    m_footFrameGenZmp.tm = m_qRef.tm;
+    m_footFrameGenZmp.data.x = st_port_data.ref_zmp(0);
+    m_footFrameGenZmp.data.y = st_port_data.ref_zmp(1);
+    m_footFrameGenZmp.data.z = st_port_data.ref_zmp(2);
+    m_footFrameGenZmpOut.write();
 
-    m_originNewRefZmp.tm = m_qRef.tm;
-    m_originNewRefZmp.data.x = st_port_data.new_ref_zmp(0);
-    m_originNewRefZmp.data.y = st_port_data.new_ref_zmp(1);
-    m_originNewRefZmp.data.z = st_port_data.new_ref_zmp(2);
-    m_originNewRefZmpOut.write();
+    m_footFrameModZmp.tm = m_qRef.tm;
+    m_footFrameModZmp.data.x = st_port_data.new_ref_zmp(0);
+    m_footFrameModZmp.data.y = st_port_data.new_ref_zmp(1);
+    m_footFrameModZmp.data.z = st_port_data.new_ref_zmp(2);
+    m_footFrameModZmpOut.write();
 
-    m_originActZmp.tm = m_qRef.tm;
-    m_originActZmp.data.x = st_port_data.act_zmp(0);
-    m_originActZmp.data.y = st_port_data.act_zmp(1);
-    m_originActZmp.data.z = st_port_data.act_zmp(2);
-    m_originActZmpOut.write();
+    m_footFrameActZmp.tm = m_qRef.tm;
+    m_footFrameActZmp.data.x = st_port_data.act_zmp(0);
+    m_footFrameActZmp.data.y = st_port_data.act_zmp(1);
+    m_footFrameActZmp.data.z = st_port_data.act_zmp(2);
+    m_footFrameActZmpOut.write();
 
-    m_footOriginRefCog.tm = m_qRef.tm;
-    m_footOriginRefCog.data.x = st_port_data.origin_ref_cog(0);
-    m_footOriginRefCog.data.y = st_port_data.origin_ref_cog(1);
-    m_footOriginRefCog.data.z = st_port_data.origin_ref_cog(2);
-    m_footOriginRefCogOut.write();
+    m_footFrameGenCog.tm = m_qRef.tm;
+    m_footFrameGenCog.data.x = st_port_data.origin_ref_cog(0);
+    m_footFrameGenCog.data.y = st_port_data.origin_ref_cog(1);
+    m_footFrameGenCog.data.z = st_port_data.origin_ref_cog(2);
+    m_footFrameGenCogOut.write();
 
-    m_footOriginActCog.tm = m_qRef.tm;
-    m_footOriginActCog.data.x = st_port_data.origin_act_cog(0);
-    m_footOriginActCog.data.y = st_port_data.origin_act_cog(1);
-    m_footOriginActCog.data.z = st_port_data.origin_act_cog(2);
-    m_footOriginActCogOut.write();
+    m_footFrameActCog.tm = m_qRef.tm;
+    m_footFrameActCog.data.x = st_port_data.origin_act_cog(0);
+    m_footFrameActCog.data.y = st_port_data.origin_act_cog(1);
+    m_footFrameActCog.data.z = st_port_data.origin_act_cog(2);
+    m_footFrameActCogOut.write();
 
     {
         m_actContactStates.tm = m_qRef.tm;
@@ -860,12 +860,12 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
     }
 
     {
-        m_newRefWrenches.tm = m_qRef.tm;
+        m_modWrenches.tm = m_qRef.tm;
         const size_t ref_wrenches_size = st_port_data.ref_wrenches.size();
         for (size_t i = 0; i < ref_wrenches_size; ++i) {
-            m_newRefWrenches.data[i] = st_port_data.ref_wrenches[i];
+            m_modWrenches.data[i] = st_port_data.ref_wrenches[i];
         }
-        m_newRefWrenchesOut.write();
+        m_modWrenchesOut.write();
     }
 
     m_emergencySignal.tm = m_qRef.tm;
@@ -875,56 +875,56 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
         m_emergencySignalOut.write();
     }
 
-    m_refCP.tm = m_qRef.tm;
+    m_baseFrameGenCp.tm = m_qRef.tm;
     const hrp::Vector3 rel_ref_cp = st->getOriginRefCP();
-    m_refCP.data.x = rel_ref_cp(0);
-    m_refCP.data.y = rel_ref_cp(1);
-    m_refCP.data.z = rel_ref_cp(2);
-    m_refCPOut.write();
+    m_baseFrameGenCp.data.x = rel_ref_cp(0);
+    m_baseFrameGenCp.data.y = rel_ref_cp(1);
+    m_baseFrameGenCp.data.z = rel_ref_cp(2);
+    m_baseFrameGenCpOut.write();
 
-    m_actCP.tm = m_qRef.tm;
+    m_baseFrameActCp.tm = m_qRef.tm;
     const hrp::Vector3 rel_act_cp = st->getOriginActCP();
-    m_actCP.data.x = rel_act_cp(0);
-    m_actCP.data.y = rel_act_cp(1);
-    m_actCP.data.z = rel_act_cp(2);
-    m_actCPOut.write();
+    m_baseFrameActCp.data.x = rel_act_cp(0);
+    m_baseFrameActCp.data.y = rel_act_cp(1);
+    m_baseFrameActCp.data.z = rel_act_cp(2);
+    m_baseFrameActCpOut.write();
 
     {
-        m_COPInfo.tm = m_qRef.tm;
+        m_eeOriginCopInfo.tm = m_qRef.tm;
         const std::vector<hrp::Vector3> contact_cop_info = st->getContactCOPInfo();
         const size_t contact_size = contact_cop_info.size();
         for (size_t i = 0; i < contact_size; ++i) {
             for (size_t j = 0; j < 3; ++j) {
-                m_COPInfo.data[i * 3 + j] = contact_cop_info[i][j];
+                m_eeOriginCopInfo.data[i * 3 + j] = contact_cop_info[i][j];
             }
         }
-        m_COPInfoOut.write();
+        m_eeOriginCopInfoOut.write();
     }
 
     if (st->getIfChangeServoGains()) {
         std::cerr << "[" << m_profile.instance_name << "] Change servo gains" << std::endl;
         st->setIfChangeServoGains(false);
 
-        m_pgain.tm = m_qRef.tm;
-        m_dgain.tm = m_qRef.tm;
-        m_tqpgain.tm = m_qRef.tm;
-        // m_tqdgain.tm = m_qRef.tm;
-        m_gainTransitionTime.tm = m_qRef.tm;
+        m_modPgain.tm = m_qRef.tm;
+        m_modDgain.tm = m_qRef.tm;
+        m_modTqPgain.tm = m_qRef.tm;
+        // m_modTqDgain.tm = m_qRef.tm;
+        m_modGainTransitionTime.tm = m_qRef.tm;
 
-        const size_t num_joints = m_pgain.data.length();
+        const size_t num_joints = m_modPgain.data.length();
         for (size_t i = 0; i < num_joints; ++i) {
-            m_pgain.data[i] = st_port_data.servo_pgains[i];
-            m_dgain.data[i] = st_port_data.servo_dgains[i];
-            m_tqpgain.data[i] = st_port_data.servo_tqpgains[i];
-            // m_tqdgain.data[i] = st_port_data.servo_tqdgains[i];
-            m_gainTransitionTime.data[i] = st_port_data.gains_transition_times[i];
+            m_modPgain.data[i] = st_port_data.servo_pgains[i];
+            m_modDgain.data[i] = st_port_data.servo_dgains[i];
+            m_modTqPgain.data[i] = st_port_data.servo_tqpgains[i];
+            // m_modTqDgain.data[i] = st_port_data.servo_tqdgains[i];
+            m_modGainTransitionTime.data[i] = st_port_data.gains_transition_times[i];
         }
 
-        m_pgainOut.write();
-        m_dgainOut.write();
-        m_tqpgainOut.write();
-        // m_tqdgainOut.write();
-        m_gainTransitionTimeOut.write();
+        m_modPgainOut.write();
+        m_modDgainOut.write();
+        m_modTqPgainOut.write();
+        // m_modTqDgainOut.write();
+        m_modGainTransitionTimeOut.write();
     }
 }
 

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -795,13 +795,6 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
     m_accRef.data.az = acc_ref(2);
     m_accRefOut.write();
 
-    m_refCP.tm = m_qRef.tm;
-    const hrp::Vector3 ref_cp = gg->calcCP();
-    m_refCP.data.x = ref_cp(0);
-    m_refCP.data.y = ref_cp(1);
-    m_refCP.data.z = ref_cp(2);
-    m_refCPOut.write();
-
     // control parameters
     {
         m_refContactStates.tm = m_qRef.tm;
@@ -881,6 +874,13 @@ void AutoBalanceStabilizer::writeOutPortData(const hrp::Vector3& base_pos,
         m_emergencySignal.data = emergency_signal_pair.second;
         m_emergencySignalOut.write();
     }
+
+    m_refCP.tm = m_qRef.tm;
+    const hrp::Vector3 rel_ref_cp = st->getOriginRefCP();
+    m_refCP.data.x = rel_ref_cp(0);
+    m_refCP.data.y = rel_ref_cp(1);
+    m_refCP.data.z = rel_ref_cp(2);
+    m_refCPOut.write();
 
     m_actCP.tm = m_qRef.tm;
     const hrp::Vector3 rel_act_cp = st->getOriginActCP();

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
@@ -181,10 +181,6 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
     InPort<TimedDoubleSeq> m_optionalDataIn;
     std::vector<TimedDoubleSeq> m_ref_force;
     std::vector<InPort<TimedDoubleSeq> *> m_ref_forceIn;
-    TimedPoint3D m_refFootOriginExtMoment;
-    InPort<TimedPoint3D> m_refFootOriginExtMomentIn;
-    TimedBoolean m_refFootOriginExtMomentIsHoldValue;
-    InPort<TimedBoolean> m_refFootOriginExtMomentIsHoldValueIn;
     std::vector<TimedDoubleSeq> m_wrenches;
     std::vector<InPort<TimedDoubleSeq> *> m_wrenchesIn;
 
@@ -205,8 +201,6 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
     OutPort<TimedDoubleSeq> m_controlSwingSupportTimeOut;
     TimedPoint3D m_sbpCogOffset;
     OutPort<TimedPoint3D> m_sbpCogOffsetOut;
-    TimedPoint3D m_diffFootOriginExtMoment;
-    OutPort<TimedPoint3D> m_diffFootOriginExtMomentOut;
     TimedLong m_emergencySignal;
     OutPort<TimedLong> m_emergencySignalOut;
     TimedDoubleSeq m_pgain;
@@ -391,8 +385,6 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
 
     std::vector<bool> ref_contact_states; // TODO: delete
     std::vector<double> control_swing_support_time; // TODO: delete
-    hrp::Vector3 ref_foot_origin_ext_moment;
-    bool is_ref_foot_origin_ext_moment_hold_value;
 
     std::unique_ptr<hrp::Stabilizer> st;
 

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
@@ -197,8 +197,6 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
     OutPort<TimedAcceleration3D> m_accRefOut;
     TimedLongSeq m_refContactStates;
     OutPort<TimedLongSeq> m_refContactStatesOut;
-    TimedDoubleSeq m_controlSwingSupportTime;
-    OutPort<TimedDoubleSeq> m_controlSwingSupportTimeOut;
     TimedPoint3D m_sbpCogOffset;
     OutPort<TimedPoint3D> m_sbpCogOffsetOut;
     TimedLong m_emergencySignal;

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
@@ -165,20 +165,20 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
 
     // DataInPort declaration
     // <rtc-template block="inport_declare">
-    TimedDoubleSeq m_qCurrent;
-    InPort<TimedDoubleSeq> m_qCurrentIn;
+    TimedDoubleSeq m_qAct;
+    InPort<TimedDoubleSeq> m_qActIn;
     TimedDoubleSeq m_qRef;
     InPort<TimedDoubleSeq> m_qRefIn;
-    TimedOrientation3D m_rpy;
-    InPort<TimedOrientation3D> m_rpyIn;
-    TimedPoint3D m_basePos;
-    InPort<TimedPoint3D> m_basePosIn;
-    TimedOrientation3D m_baseRpy;
-    InPort<TimedOrientation3D> m_baseRpyIn;
-    TimedPoint3D m_refZmp;
-    InPort<TimedPoint3D> m_refZmpIn;
-    TimedDoubleSeq m_optionalData;
-    InPort<TimedDoubleSeq> m_optionalDataIn;
+    TimedOrientation3D m_actImuRpy;
+    InPort<TimedOrientation3D> m_actImuRpyIn;
+    TimedPoint3D m_comBasePos;
+    InPort<TimedPoint3D> m_comBasePosIn;
+    TimedOrientation3D m_comBaseRpy;
+    InPort<TimedOrientation3D> m_comBaseRpyIn;
+    TimedPoint3D m_comZmp;
+    InPort<TimedPoint3D> m_comZmpIn;
+    TimedDoubleSeq m_comOptionalData;
+    InPort<TimedDoubleSeq> m_comOptionalDataIn;
     std::vector<TimedDoubleSeq> m_ref_force;
     std::vector<InPort<TimedDoubleSeq> *> m_ref_forceIn;
     std::vector<TimedDoubleSeq> m_wrenches;
@@ -187,80 +187,83 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
     // DataOutPort declaration
     // <rtc-template block="outport_declare">
     OutPort<TimedDoubleSeq> m_qOut;
-    TimedDoubleSeq m_tau;
-    OutPort<TimedDoubleSeq> m_tauOut;
-    OutPort<TimedPoint3D> m_basePosOut;
-    OutPort<TimedOrientation3D> m_baseRpyOut;
-    TimedPose3D m_basePose;
-    OutPort<TimedPose3D> m_basePoseOut;
-    TimedAcceleration3D m_accRef;
-    OutPort<TimedAcceleration3D> m_accRefOut;
-    TimedLongSeq m_refContactStates;
-    OutPort<TimedLongSeq> m_refContactStatesOut;
-    TimedPoint3D m_sbpCogOffset;
-    OutPort<TimedPoint3D> m_sbpCogOffsetOut;
+    TimedPoint3D m_genBasePos;
+    OutPort<TimedPoint3D> m_genBasePosOut;
+    TimedOrientation3D m_genBaseRpy;
+    OutPort<TimedOrientation3D> m_genBaseRpyOut;
+    TimedPose3D m_genBasePose;
+    OutPort<TimedPose3D> m_genBasePoseOut;
+    TimedAcceleration3D m_ikImuAcc;
+    OutPort<TimedAcceleration3D> m_ikImuAccOut;
     TimedLong m_emergencySignal;
     OutPort<TimedLong> m_emergencySignalOut;
-    TimedDoubleSeq m_pgain;
-    OutPort<TimedDoubleSeq> m_pgainOut;
-    TimedDoubleSeq m_dgain;
-    OutPort<TimedDoubleSeq> m_dgainOut;
-    TimedDoubleSeq m_tqpgain;
-    OutPort<TimedDoubleSeq> m_tqpgainOut;
-    // TimedDoubleSeq m_tqdgain;
-    // OutPort<TimedDoubleSeq> m_tqdgainOut;
-    TimedDoubleSeq m_gainTransitionTime;
-    OutPort<TimedDoubleSeq> m_gainTransitionTimeOut;
 
     // for debug
-    TimedDoubleSeq m_baseTform;
-    OutPort<TimedDoubleSeq> m_baseTformOut;
-    OutPort<TimedPoint3D> m_refZmpOut;
+    TimedDoubleSeq m_genBaseTform;
+    OutPort<TimedDoubleSeq> m_genBaseTformOut;
+    TimedPoint3D m_genZmp;
+    OutPort<TimedPoint3D> m_genZmpOut;
     TimedPoint3D m_nominalZmp;
     OutPort<TimedPoint3D> m_nominalZmpOut;
-    TimedPoint3D m_refEndCp;
-    OutPort<TimedPoint3D> m_refEndCpOut;
-    TimedPoint3D m_newRefCp;
-    OutPort<TimedPoint3D> m_newRefCpOut;
-    TimedDoubleSeq m_remainTime;
-    OutPort<TimedDoubleSeq> m_remainTimeOut;
-    TimedPoint3D m_refCmp; // Calculated by cog trajectory
-    OutPort<TimedPoint3D> m_refCmpOut;
-    TimedPoint3D m_baseOriginRefZmp;
-    OutPort<TimedPoint3D> m_baseOriginRefZmpOut;
-    TimedPoint3D m_refCog;
-    OutPort<TimedPoint3D> m_refCogOut;
-    TimedPoint3D m_refCogVel;
-    OutPort<TimedPoint3D> m_refCogVelOut;
-    TimedPoint3D m_refCogAcc;
-    OutPort<TimedPoint3D> m_refCogAccOut;
-    TimedPoint3D m_refAngularMomentumRPY;
-    OutPort<TimedPoint3D> m_refAngularMomentumRPYOut;
+    TimedPoint3D m_genEndCp;
+    OutPort<TimedPoint3D> m_genEndCpOut;
+    TimedPoint3D m_genCp;
+    OutPort<TimedPoint3D> m_genCpOut;
+    TimedDoubleSeq m_genRemainTime;
+    OutPort<TimedDoubleSeq> m_genRemainTimeOut;
+    TimedPoint3D m_genCmp; // Calculated by cog trajectory
+    OutPort<TimedPoint3D> m_genCmpOut;
+    TimedPoint3D m_baseFrameGenZmp;
+    OutPort<TimedPoint3D> m_baseFrameGenZmpOut;
+    TimedPoint3D m_genCog;
+    OutPort<TimedPoint3D> m_genCogOut;
+    TimedPoint3D m_genCogVel;
+    OutPort<TimedPoint3D> m_genCogVelOut;
+    TimedPoint3D m_genCogAcc;
+    OutPort<TimedPoint3D> m_genCogAccOut;
+    TimedPoint3D m_genAngularMomentumRpy;
+    OutPort<TimedPoint3D> m_genAngularMomentumRpyOut;
+    TimedPoint3D m_genSbpCogOffset;
+    OutPort<TimedPoint3D> m_genSbpCogOffsetOut;
+    TimedPoint3D m_baseFrameGenCp;
+    OutPort<TimedPoint3D> m_baseFrameGenCpOut;
+    TimedLongSeq m_genContactStates;
+    OutPort<TimedLongSeq> m_genContactStatesOut;
     // Data from Stabilizer
+    TimedDoubleSeq m_modTau;
+    OutPort<TimedDoubleSeq> m_modTauOut;
     TimedOrientation3D m_actBaseRpy;
     OutPort<TimedOrientation3D> m_actBaseRpyOut;
-    TimedPoint3D m_baseOriginActZmp;
-    OutPort<TimedPoint3D> m_baseOriginActZmpOut;
-    TimedPoint3D m_originRefZmp;
-    OutPort<TimedPoint3D> m_originRefZmpOut;
-    TimedPoint3D m_originNewRefZmp;
-    OutPort<TimedPoint3D> m_originNewRefZmpOut;
-    TimedPoint3D m_originActZmp;
-    OutPort<TimedPoint3D> m_originActZmpOut;
-    TimedPoint3D m_footOriginRefCog;
-    OutPort<TimedPoint3D> m_footOriginRefCogOut;
-    TimedPoint3D m_footOriginActCog;
-    OutPort<TimedPoint3D> m_footOriginActCogOut;
+    TimedPoint3D m_baseFrameActZmp;
+    OutPort<TimedPoint3D> m_baseFrameActZmpOut;
+    TimedPoint3D m_footFrameGenZmp;
+    OutPort<TimedPoint3D> m_footFrameGenZmpOut;
+    TimedPoint3D m_footFrameModZmp;
+    OutPort<TimedPoint3D> m_footFrameModZmpOut;
+    TimedPoint3D m_footFrameActZmp;
+    OutPort<TimedPoint3D> m_footFrameActZmpOut;
+    TimedPoint3D m_footFrameGenCog;
+    OutPort<TimedPoint3D> m_footFrameGenCogOut;
+    TimedPoint3D m_footFrameActCog;
+    OutPort<TimedPoint3D> m_footFrameActCogOut;
     TimedBooleanSeq m_actContactStates;
     OutPort<TimedBooleanSeq> m_actContactStatesOut;
-    TimedDoubleSeq m_newRefWrenches;
-    OutPort<TimedDoubleSeq> m_newRefWrenchesOut;
-    TimedPoint3D m_refCP;
-    OutPort<TimedPoint3D> m_refCPOut;
-    TimedPoint3D m_actCP;
-    OutPort<TimedPoint3D> m_actCPOut;
-    TimedDoubleSeq m_COPInfo;
-    OutPort<TimedDoubleSeq> m_COPInfoOut;
+    TimedDoubleSeq m_modWrenches;
+    OutPort<TimedDoubleSeq> m_modWrenchesOut;
+    TimedPoint3D m_baseFrameActCp;
+    OutPort<TimedPoint3D> m_baseFrameActCpOut;
+    TimedDoubleSeq m_eeOriginCopInfo;
+    OutPort<TimedDoubleSeq> m_eeOriginCopInfoOut;
+    TimedDoubleSeq m_modPgain;
+    OutPort<TimedDoubleSeq> m_modPgainOut;
+    TimedDoubleSeq m_modDgain;
+    OutPort<TimedDoubleSeq> m_modDgainOut;
+    TimedDoubleSeq m_modTqPgain;
+    OutPort<TimedDoubleSeq> m_modTqPgainOut;
+    // TimedDoubleSeq m_modTqDgain;
+    // OutPort<TimedDoubleSeq> m_modTqDgainOut;
+    TimedDoubleSeq m_modGainTransitionTime;
+    OutPort<TimedDoubleSeq> m_modGainTransitionTimeOut;
 
     // CORBA Port declaration
     // <rtc-template block="corbaport_declare">
@@ -365,7 +368,7 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
     // hrp::Vector3 calc_vel_from_hand_error (const rats::coordinates& tmp_fix_coords);
     // bool isOptionalDataContact (const std::string& ee_name)
     // {
-    //     return (std::fabs(m_optionalData.data[contact_states_index_map[ee_name]] - 1.0) < 0.1) ? true : false;
+    //     return (std::fabs(m_comOptionalData.data[contact_states_index_map[ee_name]] - 1.0) < 0.1) ? true : false;
     // }
     std::string getUseForceModeString ();
 

--- a/rtc/AutoBalanceStabilizer/Stabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/Stabilizer.cpp
@@ -760,8 +760,6 @@ void Stabilizer::calcActualParameters(const paramsFromSensors& sensor_param)
                               << "d_foot_rpy (" << ee_name[i] << ")  = [" << rad2deg(stikp[i].d_foot_rpy(0)) << " " << rad2deg(stikp[i].d_foot_rpy(1)) << " " << rad2deg(stikp[i].d_foot_rpy(2)) << "] [deg]" << std::endl;
                 }
             }
-
-            calcDiffFootOriginExtMoment();
         }
     } // st_algorithm != OpenHRP::AutoBalanceStabilizerService::TPCC
 
@@ -1373,37 +1371,6 @@ double Stabilizer::calcDampingControl(const double prev_d, const double TT)
 hrp::Vector3 Stabilizer::calcDampingControl(const hrp::Vector3& prev_d, const hrp::Vector3& TT)
 {
     return (-prev_d.cwiseQuotient(TT)) * dt + prev_d;
-}
-
-void Stabilizer::calcDiffFootOriginExtMoment()
-{
-    // calc reference ext moment around foot origin pos
-    const double mg = total_mass * g_acc; // TODO: g_accを消す
-    const hrp::Vector3 ref_ext_moment(mg  * ref_cog(1) - ref_total_foot_origin_moment(0),
-                                      -mg * ref_cog(0) - ref_total_foot_origin_moment(1),
-                                       0);
-    // calc act ext moment around foot origin pops
-    hrp::Vector3 act_ext_moment;
-    // Do not calculate actual value if in the air, because of invalid act_zmp.
-    if (on_ground) act_ext_moment = hrp::Vector3(mg  * act_cog(1) - act_total_foot_origin_moment(0),
-                                                 -mg * act_cog(0) - act_total_foot_origin_moment(1),
-                                                 0);
-    else act_ext_moment = ref_ext_moment;
-
-    // Calc diff
-    diff_foot_origin_ext_moment = ref_ext_moment - act_ext_moment;
-
-    if (DEBUGP(loop)) {
-        std::cerr << "[" << comp_name << "] DiffStaticBalancePointOffset\n";
-        std::cerr << "[" << comp_name << "]   "
-                  << "ref_ext_moment = "
-                  << ref_ext_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]"))
-                  << "[mm], " << "act_ext_moment = "
-                  << act_ext_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]"))
-                  << "[mm], " << "diff ext_moment = "
-                  << diff_foot_origin_ext_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]"))
-                  << "[mm]" << std::endl;
-    }
 }
 
 void Stabilizer::setSwingSupportJointServoGains()

--- a/rtc/AutoBalanceStabilizer/Stabilizer.h
+++ b/rtc/AutoBalanceStabilizer/Stabilizer.h
@@ -139,7 +139,6 @@ class Stabilizer
 
     // Getter for AutoBalanceStabilizer
     std::vector<bool> getActContactStates() const { return act_contact_states; }
-    hrp::Vector3 getDiffFootOriginExtMoment() const { return diff_foot_origin_ext_moment; }
     std::vector<hrp::Vector3> getContactCOPInfo() const  { return contact_cop_info; }
     hrp::Vector3 getOriginRefCP() const { return rel_ref_cp; }
     hrp::Vector3 getOriginActCP() const { return rel_act_cp; }
@@ -195,7 +194,6 @@ class Stabilizer
     double calcDampingControl (const double prev_d, const double TT);
     hrp::Vector3 calcDampingControl (const hrp::Vector3& tau_d, const hrp::Vector3& tau, const hrp::Vector3& prev_d,
                                      const hrp::Vector3& DD, const hrp::Vector3& TT);
-    void calcDiffFootOriginExtMoment ();
     void setSwingSupportJointServoGains();
     void calcExternalForce(const hrp::Vector3& cog, const hrp::Vector3& zmp, const hrp::Matrix33& rot);
     void calcTorque(const hrp::Matrix33& rot);
@@ -284,7 +282,6 @@ class Stabilizer
 
     // Port data for AutoBalanceStabilizer
     int emergency_signal = 0;
-    hrp::Vector3 diff_foot_origin_ext_moment = hrp::Vector3::Zero();
 
     // TODO: 整理
     int transition_count = 0;


### PR DESCRIPTION
- AutoBalanceStabilizerのデータポート名を整理
  - データポート名とデータのインスタンス名にIn/Outはつけない．ポートのインスタンス名にはつける
  - 修飾語
    - com：上位からの指令値．commandの略
    - gen：旧abc部分が生成した計画値．generatedの略
    - mod：旧st部分が生成した修正値．modifiedの略
    - act：センサ値（フィルタ適用後も該当）．actualの略
    - ik：逆運動学を解いた結果の値
- refCPのデータポートに入っていたCapturePointをルートリンク相対の値に修正
- controlSwingSupportTimeはgenRemainTimeと重複していたので削除
- diffFootOriginExtMomentは @YutaKojio 的に不要とのことだったので削除
- 元来rosbridgeに出力していたデータをLogから削除
