### PR TITLE
add stateEstimator

### DIFF
--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -364,7 +364,8 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onExecute(RTC::UniqueId ec_id)
     readInportData();
     updateBodyParams();
     if(!gg->getWalkingState()) gg->setConstraintToFootCoord(m_robot);
-    act_se->calcStates(hrp::stateInputData{q_act, act_rpy, act_wrenches, gg->getCurrentConstraints(loop), ref_zmp(2)});
+    gg->forwardTimeStep(loop);
+    act_se->calcStates(hrp::stateInputData{q_act, act_rpy, act_wrenches, gg->getCurrentConstraints(loop), ref_zmp(2), gg->getCurConstIdx()});
 
     gg->setDebugLevel(m_debugLevel);
 
@@ -372,7 +373,6 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onExecute(RTC::UniqueId ec_id)
         // adjustCOPCoordToTarget();
 
         // 脚軌道, COP, RootLink計算
-        gg->forwardTimeStep(loop);
         gg->calcCogAndLimbTrajectory(loop, m_dt);
         gg_is_walking = gg->getWalkingState();
         ref_zmp = gg->getRefZMP();

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -363,7 +363,7 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onExecute(RTC::UniqueId ec_id)
     gg->setCurrentLoop(loop);
     readInportData();
     updateBodyParams();
-    if(!gg_is_walking) gg->setConstraintToFootCoord(m_robot);
+    if(!gg->getWalkingState()) gg->setConstraintToFootCoord(m_robot);
     act_se->calcStates(hrp::stateInputData{q_act, act_rpy, act_wrenches, gg->getCurrentConstraints(loop), ref_zmp(2)});
 
     gg->setDebugLevel(m_debugLevel);
@@ -942,13 +942,24 @@ void AutoBalanceStabilizer::updateBodyParams()
     m_robot->rootLink()->p = ref_base_pos;
     m_robot->rootLink()->R = ref_base_rot;
     m_robot->calcForwardKinematics();
+    if (control_mode != MODE_IDLE) fixLegToCoords();
 
     copyJointAnglesToRobotModel(m_act_robot, q_act);
     const hrp::Sensor* const gyro = m_act_robot->sensor<hrp::RateGyroSensor>("gyrometer");
     const hrp::Matrix33 gyro_R = gyro->link->R * gyro->localR;
-    m_act_robot->rootLink()->p = ref_base_pos; // actの原点位置は0でなくrefと同じになった
+    m_act_robot->rootLink()->p = m_robot->rootLink()->p; // actの原点位置は0でなくrefと同じになった
     m_act_robot->rootLink()->R = hrp::rotFromRpy(act_rpy) * (gyro_R.transpose() * m_act_robot->rootLink()->R);
     m_act_robot->calcForwardKinematics();
+}
+
+void AutoBalanceStabilizer::fixLegToCoords()
+{
+    const auto& cur_constraints = gg->getCurrentConstraints(loop);
+    const Eigen::Isometry3d constraint_origin_coord = cur_constraints.calcCOPOriginCoord();
+    const Eigen::Isometry3d foot_origin_coord = cur_constraints.calcFootOriginCoord(m_robot);
+    m_robot->rootLink()->p = constraint_origin_coord * foot_origin_coord.inverse() * m_robot->rootLink()->p;
+    m_robot->rootLink()->R = constraint_origin_coord.linear() * foot_origin_coord.linear().transpose() * m_robot->rootLink()->R;
+    m_robot->calcForwardKinematics();
 }
 
 std::vector<hrp::LinkConstraint> AutoBalanceStabilizer::readContactPointsFromProps(const RTC::Properties& prop, std::vector<int>& contacts_link_indices)

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -324,6 +324,8 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onInitialize()
     additional_force_applied_point_offset = hrp::Vector3::Zero();
 
     m_act_robot = boost::make_shared<hrp::Body>(*m_robot);
+    act_se = std::make_unique<hrp::StateEstimator>(m_act_robot, std::string(m_profile.instance_name) + "_SE", m_dt, m_mutex);
+
     return RTC::RTC_OK;
 }
 
@@ -497,6 +499,8 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onExecute(RTC::UniqueId ec_id)
                      gg->getCog(), gg->getCogVel(), gg->getCogAcc(),
                      ref_angular_momentum, sbp_cog_offset,
                      kf_acc_ref, st->getStabilizerPortData());
+
+    m_act_robot->rootLink()->R = ref_baseRot;
 
     return RTC::RTC_OK;
 }
@@ -938,7 +942,7 @@ void AutoBalanceStabilizer::updateBodyParams()
     copyJointAnglesToRobotModel(m_act_robot, q_act);
     const hrp::Sensor* const gyro = m_act_robot->sensor<hrp::RateGyroSensor>("gyrometer");
     const hrp::Matrix33 gyro_R = gyro->link->R * gyro->localR;
-    m_act_robot->rootLink()->p = ref_base_pos;
+    m_act_robot->rootLink()->p = ref_base_pos; // actの原点位置は0でなくrefと同じになった
     m_act_robot->rootLink()->R = hrp::rotFromRpy(act_rpy) * (gyro_R.transpose() * m_act_robot->rootLink()->R);
     m_act_robot->calcForwardKinematics();
 }

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -371,6 +371,7 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onExecute(RTC::UniqueId ec_id)
         // 脚軌道, COP, RootLink計算
         gg->forwardTimeStep(loop);
         gg->calcCogAndLimbTrajectory(loop, m_dt);
+        gg_is_walking = gg->getWalkingState();
         ref_zmp = gg->getRefZMP();
 
         // TODO: rootlink計算
@@ -1363,7 +1364,7 @@ bool AutoBalanceStabilizer::startWalking()
 
 void AutoBalanceStabilizer::stopWalking ()
 {
-    gg_is_walking = false;
+    gg->setWalkingState(false);
 }
 
 bool AutoBalanceStabilizer::startAutoBalancer(const OpenHRP::AutoBalanceStabilizerService::StrSequence& limbs)
@@ -1460,7 +1461,7 @@ bool AutoBalanceStabilizer::goPos(const double x, const double y, const double t
     if (!gg->goPos(target, support_link_cycle, swing_link_cycle)) return false;
 
     Guard guard(m_mutex);
-    gg_is_walking = true; // TODO: 自動でgg_is_walkingをfalseにする & constraintsのclear
+    gg->setWalkingState(true);
 
     return true;
 }
@@ -1530,7 +1531,7 @@ bool AutoBalanceStabilizer::setFootSteps(const OpenHRP::AutoBalanceStabilizerSer
     if (!gg->setFootSteps(support_link_cycle, swing_link_cycle, footsteps_pos, footsteps_rot, fs_side, length)) return false;
 
     Guard guard(m_mutex);
-    gg_is_walking = true; // TODO: 自動でgg_is_walkingをfalseにする & constraintsのclear
+    gg->setWalkingState(true);
 
     return true;
 }
@@ -1600,7 +1601,7 @@ bool AutoBalanceStabilizer::setRunningFootSteps(const OpenHRP::AutoBalanceStabil
     if (!gg->setRunningFootSteps(support_link_cycle, swing_link_cycle, footsteps_pos, footsteps_rot, fs_side, length, m_dt)) return false;
 
     Guard guard(m_mutex);
-    gg_is_walking = true; // TODO: 自動でgg_is_walkingをfalseにする & constraintsのclear
+    gg->setWalkingState(true);
 
     return true;
 }

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.cpp
@@ -362,6 +362,7 @@ RTC::ReturnCode_t AutoBalanceStabilizer::onExecute(RTC::UniqueId ec_id)
     gg->setCurrentLoop(loop);
     readInportData();
     updateBodyParams();
+    if(!gg_is_walking) gg->setConstraintToFootCoord(m_robot);
 
     gg->setDebugLevel(m_debugLevel);
 

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
@@ -328,6 +328,7 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
     // -- Functions for OpenRTM port --
 
     void updateBodyParams();
+    void fixLegToCoords();
     std::vector<hrp::LinkConstraint> readContactPointsFromProps(const RTC::Properties& prop, std::vector<int>& contacts_link_indices);
 
     // void addBodyConstraint(std::vector<hrp::LinkConstraint>& constraints,

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
@@ -328,7 +328,7 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
     // -- Functions for OpenRTM port --
 
     void updateBodyParams();
-    std::vector<hrp::LinkConstraint> readContactPointsFromProps(const RTC::Properties& prop);
+    std::vector<hrp::LinkConstraint> readContactPointsFromProps(const RTC::Properties& prop, std::vector<int>& contacts_link_indices);
 
     // void addBodyConstraint(std::vector<hrp::LinkConstraint>& constraints,
     //                        const hrp::BodyPtr& _robot);

--- a/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
+++ b/rtc/AutoBalanceStabilizer/AutoBalanceStabilizer.h
@@ -32,6 +32,7 @@
 #include "FullbodyInverseKinematicsSolver.h"
 #include "GaitGenerator.h"
 #include "Stabilizer.h"
+#include "StateEstimator.h"
 // Service implementation headers
 // <rtc-template block="service_impl_h">
 #include "AutoBalanceStabilizerService_impl.h"
@@ -388,6 +389,9 @@ class AutoBalanceStabilizer : public RTC::DataFlowComponentBase
     std::vector<double> control_swing_support_time; // TODO: delete
 
     std::unique_ptr<hrp::Stabilizer> st;
+
+    // for se
+    std::unique_ptr<hrp::StateEstimator> act_se;
 
     // for gg
     std::unique_ptr<hrp::GaitGenerator> gg;

--- a/rtc/AutoBalanceStabilizer/CMakeLists.txt
+++ b/rtc/AutoBalanceStabilizer/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 set(comp_sources AutoBalanceStabilizer.cpp AutoBalanceStabilizerService_impl.cpp ../SequencePlayer/interpolator.cpp ../TorqueFilter/IIRFilter.cpp)
 set(libs hrpModel-3.1 hrpCollision-3.1 hrpUtil-3.1 hrpsysBaseStub)
-set(abst_libs EigenUtil LinkConstraint GaitGenerator Stabilizer)
+set(abst_libs EigenUtil LinkConstraint GaitGenerator Stabilizer StateEstimator)
 
 include_directories(${PROJECT_SOURCE_DIR}/rtc/SequencePlayer)
 
@@ -60,7 +60,7 @@ target_link_libraries(testZMPDistributorABS ${libs})
 # add_test(testZMPDistributor_JAXONRED_EEFMQPCOP_Test2 testZMPDistributorABS --jaxon_red --test2 --use-gnuplot false --distribution-algorithm EEFMQPCOP)
 
 # set(target AutoBalanceStabilizer AutoBalanceStabilizerComp EigenUtil LinkConstraint GaitGenerator Stabilizer testRefZMPGenerator testLimbTrajectoryGenerator testCOGTrajectoryGenerator testTwoDofControllerABS testZMPDistributorABS)
-set(target AutoBalanceStabilizer AutoBalanceStabilizerComp EigenUtil LinkConstraint GaitGenerator Stabilizer testRefZMPGenerator testLimbTrajectoryGenerator testTwoDofControllerABS testZMPDistributorABS)
+set(target AutoBalanceStabilizer AutoBalanceStabilizerComp EigenUtil LinkConstraint GaitGenerator Stabilizer StateEstimator testRefZMPGenerator testLimbTrajectoryGenerator testTwoDofControllerABS testZMPDistributorABS)
 
 install(TARGETS ${target}
   RUNTIME DESTINATION bin

--- a/rtc/AutoBalanceStabilizer/COGTrajectoryGenerator.cpp
+++ b/rtc/AutoBalanceStabilizer/COGTrajectoryGenerator.cpp
@@ -667,7 +667,10 @@ hrp::Vector3 COGTrajectoryGenerator::calcFootGuidedCogWalk(const std::vector<Con
     if (landing_idx == cur_const_idx) {
         constexpr double PREVIEW_TIME = 1.6;
         if (ref_zmp_goals[cur_zmp_idx + 1].second > cur_count) step_remain_time = const_remain_time;
-        else step_remain_time = const_remain_time = PREVIEW_TIME;
+        else {
+            step_remain_time = const_remain_time = PREVIEW_TIME;
+            is_walking = false;
+        }
     }
 
     const size_t zmp_goals_size = ref_zmp_goals.size();

--- a/rtc/AutoBalanceStabilizer/COGTrajectoryGenerator.h
+++ b/rtc/AutoBalanceStabilizer/COGTrajectoryGenerator.h
@@ -48,6 +48,8 @@ class COGTrajectoryGenerator
     CogCalculationType calculation_type = PREVIEW_CONTROL;
     std::unique_ptr<ExtendedPreviewController> preview_controller;
 
+    bool is_walking = false;
+
     void updateCogState(const hrp::Vector3& input_zmp, const double dt, const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION);
 
     // Foot guided run variables
@@ -79,6 +81,8 @@ class COGTrajectoryGenerator
     const double& getStepRemainTime() const { return step_remain_time; }
     const double& getConstRemainTime() const { return const_remain_time; }
     const double getRefCogZ() const { return ref_cog_z; }
+    const bool getWalkingState() { return is_walking; };
+    void setWalkingState(const bool _walking) { is_walking = _walking; };
     hrp::Vector3 calcCP(const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION) const { return cog + cog_vel / omega; }
     hrp::Vector3 calcPointMassZMP(const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION) const
     {

--- a/rtc/AutoBalanceStabilizer/GaitGenerator.cpp
+++ b/rtc/AutoBalanceStabilizer/GaitGenerator.cpp
@@ -1363,4 +1363,14 @@ bool GaitGenerator::startJumping(const double dt, const double g_acc)
     std::cerr << "add jump end" << std::endl;
 }
 
+void GaitGenerator::setConstraintToFootCoord(const hrp::BodyPtr& _robot)
+{
+    auto& cur_constraints = constraints_list.back().constraints;
+    for (auto& constraint : cur_constraints) {
+        const hrp::Link* const link = _robot->link(constraint.getLinkId());
+        constraint.targetPos() = constraint.calcActualTargetPosFromLinkState(link->p, link->R);
+        constraint.targetRot() = constraint.calcActualTargetRotFromLinkState(link->R);
+    }
+}
+
 }

--- a/rtc/AutoBalanceStabilizer/GaitGenerator.h
+++ b/rtc/AutoBalanceStabilizer/GaitGenerator.h
@@ -165,6 +165,9 @@ class GaitGenerator
     const hrp::Vector3& getNewRefCP() const { return cog_gen->getNewRefCP(); }
     const double& getStepRemainTime() const { return cog_gen->getStepRemainTime(); }
     const double& getConstRemainTime() const { return cog_gen->getConstRemainTime(); }
+    const bool getWalkingState() { return cog_gen->getWalkingState(); };
+
+    void setWalkingState(const bool _walking) { cog_gen->setWalkingState(_walking); };
 
     // Todo: Private ?
     hrp::Vector3 calcReferenceCOPFromModel(const hrp::BodyPtr& _robot, const std::vector<LinkConstraint>& cur_consts) const;

--- a/rtc/AutoBalanceStabilizer/GaitGenerator.h
+++ b/rtc/AutoBalanceStabilizer/GaitGenerator.h
@@ -331,6 +331,8 @@ class GaitGenerator
     bool startJumping(const double dt, const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION);
     bool startRunJumpDemo(const double dt, const double g_acc = DEFAULT_GRAVITATIONAL_ACCELERATION);
 
+    void setConstraintToFootCoord(const hrp::BodyPtr& _robot);
+
     // gopos: 接触のCycleを記述したい
     // void goPos(const rats::coordinates& target, const size_t one_step_count,
     //            const double max_step_length, const double max_rotate_angle,

--- a/rtc/AutoBalanceStabilizer/GaitGenerator.h
+++ b/rtc/AutoBalanceStabilizer/GaitGenerator.h
@@ -143,6 +143,7 @@ class GaitGenerator
         const size_t index = getConstraintIndexFromCount(constraints_list, count);
         return constraints_list[index];
     }
+    const size_t getCurConstIdx() { return cur_const_idx; };
     const std::vector<ConstraintsWithCount>& getConstraintsList() const { return constraints_list; }
     void modifyConstraintsTarget(const size_t cur_count,
                                  const size_t cwc_idx_from_current,

--- a/rtc/AutoBalanceStabilizer/LinkConstraint.cpp
+++ b/rtc/AutoBalanceStabilizer/LinkConstraint.cpp
@@ -177,19 +177,7 @@ Eigen::Isometry3d ConstraintsWithCount::calcFootOriginCoord(const hrp::BodyPtr& 
         orig_quat = orig_quat.slerp(weight / sum_weight, foot_quat);
     }
     if (sum_weight > 0) coord.translation() /= sum_weight;
-    coord.linear() = orig_quat.toRotationMatrix();
-
-    { // align x-axis to en
-        hrp::Vector3 en = n / n.norm();
-        const hrp::Vector3 ex = hrp::Vector3::UnitX();
-        hrp::Vector3 xv1(coord.linear() * ex);
-        xv1 = xv1 - xv1.dot(en) * en;
-        xv1.normalize();
-        hrp::Vector3 yv1(en.cross(xv1));
-        coord.linear()(0,0) = xv1(0); coord.linear()(1,0) = xv1(1); coord.linear()(2,0) = xv1(2);
-        coord.linear()(0,1) = yv1(0); coord.linear()(1,1) = yv1(1); coord.linear()(2,1) = yv1(2);
-        coord.linear()(0,2) = en(0);  coord.linear()(1,2) = en(1);  coord.linear()(2,2) = en(2);
-    }
+    coord.linear() = hrp::alignZaxis(orig_quat.toRotationMatrix());
 
     return coord;
 }

--- a/rtc/AutoBalanceStabilizer/LinkConstraint.h
+++ b/rtc/AutoBalanceStabilizer/LinkConstraint.h
@@ -16,6 +16,8 @@
 #include <Eigen/Geometry>
 #include <hrpUtil/EigenTypes.h>
 #include "LimbTrajectoryGenerator.h"
+#include <hrpModel/Link.h>
+#include <hrpModel/Body.h>
 
 // Memo: 着地時間が例えば遅くなった時，足は待っているのかどうか．どうやって修正するか
 
@@ -216,6 +218,7 @@ struct ConstraintsWithCount
         coord.linear() = calcCOPRotationFromConstraints(type_thre);
         return coord;
     }
+    Eigen::Isometry3d calcFootOriginCoord(const hrp::BodyPtr& _robot, const hrp::Vector3& n = hrp::Vector3::UnitZ()) const;
 
     int getConstraintIndexFromLinkId(const int id) const;
     std::vector<size_t> getConstraintIndicesFromType(const LinkConstraint::ConstraintType type) const;

--- a/rtc/AutoBalanceStabilizer/LinkConstraint.h
+++ b/rtc/AutoBalanceStabilizer/LinkConstraint.h
@@ -18,6 +18,7 @@
 #include "LimbTrajectoryGenerator.h"
 #include <hrpModel/Link.h>
 #include <hrpModel/Body.h>
+#include "Utility.h"
 
 // Memo: 着地時間が例えば遅くなった時，足は待っているのかどうか．どうやって修正するか
 
@@ -219,6 +220,13 @@ struct ConstraintsWithCount
         return coord;
     }
     Eigen::Isometry3d calcFootOriginCoord(const hrp::BodyPtr& _robot, const hrp::Vector3& n = hrp::Vector3::UnitZ()) const;
+    inline Eigen::Isometry3d calcCOPOriginCoord() const
+    {
+        Eigen::Isometry3d coord;
+        coord.translation() = calcCOPFromConstraints();
+        coord.linear() = hrp::alignZaxis(calcCOPRotationFromConstraints());
+        return coord;
+    }
 
     int getConstraintIndexFromLinkId(const int id) const;
     std::vector<size_t> getConstraintIndicesFromType(const LinkConstraint::ConstraintType type) const;

--- a/rtc/AutoBalanceStabilizer/StateEstimator.cpp
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.cpp
@@ -133,45 +133,4 @@ bool StateEstimator::calcZMP(hrp::Vector3& ret_zmp, const hrp::ConstraintsWithCo
     }
 }
 
-// hrp::Vector3 StateEstimator::calcCOPFromRobotState(const hrp::BodyPtr& act_robot,
-//                                    const std::vector<LinkConstraint>& constraints,
-//                                    const LinkConstraint::ConstraintType type_thre)
-// {
-//     hrp::Vector3 cop_pos = hrp::Vector3::Zero();
-//     double sum_weight = 0;
-
-//     for (const LinkConstraint& constraint : constraints) {
-//         if (constraint.getConstraintType() >= type_thre || !constraint.isZmpCalcTarget()) continue;
-//         const double weight = constraint.getCOPWeight();
-//         const hrp::Link* const target = act_robot->link(constraint.getLinkId());
-//         cop_pos += constraint.calcActualTargetPosFromLinkState(target->p, target->R) * weight;
-//         sum_weight += weight;
-//     }
-//     if (sum_weight > 0) cop_pos /= sum_weight;
-
-//     return cop_pos;
-// }
-
-// hrp::Matrix33 StateEstimator::calcCOPRotationFromRobotState(const hrp::BodyPtr& act_robot,
-//                                             const std::vector<LinkConstraint>& constraints,
-//                                             const LinkConstraint::ConstraintType type_thre)
-// {
-//     Eigen::Quaternion<double> cop_quat = Eigen::Quaternion<double>::Identity();
-//     double sum_weight = 0;
-//     constexpr double EPS = 1e-6;
-
-//     for (const LinkConstraint& constraint : constraints) {
-//         const double weight = constraint.getCOPWeight();
-//         if (constraint.getConstraintType() >= type_thre || !constraint.isZmpCalcTarget() ||
-//             weight < EPS /* to avoid zero division */) continue;
-//         sum_weight += weight;
-
-//         const hrp::Link* const target = act_robot->link(constraint.getLinkId());
-//         const Eigen::Quaternion<double> contact_quat(constraint.calcActualTargetRotFromLinkState(target->R));
-//         cop_quat = cop_quat.slerp(weight / sum_weight, contact_quat);
-//     }
-
-//     return cop_quat.toRotationMatrix();
-// }
-
 }

--- a/rtc/AutoBalanceStabilizer/StateEstimator.cpp
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.cpp
@@ -31,79 +31,58 @@ void StateEstimator::calcStates(const stateInputData& input_data)
 
     // cog
     cog = m_robot->calcCM();
+    // zmp
+    on_ground = calcZMP(zmp, input_data.constraints, input_data.zmp_z);
 }
 
-hrp::Vector3 calcActZMP(const hrp::BodyPtr& act_robot,
-                        const std::vector<LinkConstraint>& constraints,
-                        const double zmp_z)
+bool StateEstimator::calcZMP(hrp::Vector3& ret_zmp, const hrp::ConstraintsWithCount& constraints, const double zmp_z)
 {
     // TODO: rename
-    double tmpzmpx = 0;
-    double tmpzmpy = 0;
-    double tmpfz = 0;
-    // double tmpfz2 = 0.0;
+    double tmp_zmpx = 0;
+    double tmp_zmpy = 0;
+    double tmp_fz = 0;
+    double tmp_filterd_fz = 0.0;
 
-    for (const LinkConstraint& constraint : constraints) {
+    for (const auto& constraint : constraints.constraints) {
+        const int link_id = constraint.getLinkId();
         if (!constraint.isZmpCalcTarget()) continue;
-        if (act_robot->link(constraint.getLinkId())->sensors.size() == 0) continue; // TODO: 無い場合トルク推定?
-
-        const hrp::ForceSensor* const sensor = dynamic_cast<hrp::ForceSensor*>(act_robot->link(constraint.getLinkId())->sensors[0]);
+        if (m_robot->link(link_id)->sensors.size() == 0) continue; // TODO: 無い場合トルク推定?
+        const hrp::ForceSensor* const sensor = dynamic_cast<hrp::ForceSensor*>(m_robot->link(link_id)->sensors[0]);
         if (!sensor) continue;
 
         const hrp::Matrix33 sensor_R = sensor->link->R * sensor->localR;
-        // rats::rotm3times(sensor_R, sensor->link->R, sensor->localR);
-        const hrp::Vector3 nf = sensor_R * sensor->f;
-        const hrp::Vector3 nm = sensor_R * sensor->tau;
+        hrp::Vector3 nf = sensor_R * sensor->f;
+        hrp::Vector3 nm = sensor_R * sensor->tau;
         const hrp::Vector3 sensor_p = sensor->link->p + sensor->link->R * sensor->localPos;
-        tmpzmpx += nf(2) * sensor_p(0) - (sensor_p(2) - zmp_z) * nf(0) - nm(1);
-        tmpzmpy += nf(2) * sensor_p(1) - (sensor_p(2) - zmp_z) * nf(1) + nm(0);
-        tmpfz += nf(2);
+        tmp_zmpx += nf(2) * sensor_p(0) - (sensor_p(2) - zmp_z) * nf(0) - nm(1);
+        tmp_zmpy += nf(2) * sensor_p(1) - (sensor_p(2) - zmp_z) * nf(1) + nm(0);
+        tmp_fz += nf(2);
 
         // calc ee-local COP
-        // const hrp::Link* target = m_robot->link(stikp[i].target_name);
-        // const hrp::Matrix33 eeR = target->R * stikp[i].localR;
-        // const hrp::Vector3 ee_fsp = eeR.transpose() * (fsp - (target->p + target->R * stikp[i].localp)); // ee-local force sensor pos
-        // nf = eeR.transpose() * nf;
-        // nm = eeR.transpose() * nm;
-        // // ee-local total moment and total force at ee position
-        // const double tmp_cop_mx = nf(2) * ee_fsp(1) - nf(1) * ee_fsp(2) + nm(0);
-        // const double tmp_cop_my = nf(2) * ee_fsp(0) - nf(0) * ee_fsp(2) - nm(1);
-        // const double tmp_cop_fz = nf(2);
-        // contact_cop_info[i][0] = tmp_cop_mx;
-        // contact_cop_info[i][1] = tmp_cop_my;
-        // contact_cop_info[i][2] = tmp_cop_fz;
-        // prev_act_force_z[i] = 0.85 * prev_act_force_z[i] + 0.15 * nf(2); // filter, cut off 5[Hz]
-        // tmpfz2 += prev_act_force_z[i];
+        const hrp::Link* const target = dynamic_cast<hrp::Link*>(m_robot->link(link_id));
+        const hrp::Matrix33 ee_R =  constraint.calcActualTargetRotFromLinkState(target->R);
+        const hrp::Vector3 ee_frame_senspor_p = ee_R.transpose() * (sensor_p - constraint.calcActualTargetPosFromLinkState(target->p, target->R)); // ee-local force sensor pos
+        nf = ee_R.transpose() * nf;
+        nm = ee_R.transpose() * nm;
+        // ee-local total moment and total force at ee position
+        const double tmp_cop_mx = nf(2) * ee_frame_senspor_p(1) - nf(1) * ee_frame_senspor_p(2) + nm(0);
+        const double tmp_cop_my = nf(2) * ee_frame_senspor_p(0) - nf(0) * ee_frame_senspor_p(2) - nm(1);
+        const double tmp_cop_fz = nf(2);
+        limb_param[link_id].contact_cop_info[0] = tmp_cop_mx;
+        limb_param[link_id].contact_cop_info[1] = tmp_cop_my;
+        limb_param[link_id].contact_cop_info[2] = tmp_cop_fz;
+
+        limb_param[link_id].prev_act_force_z = 0.85 * limb_param[link_id].prev_act_force_z + 0.15 * nf(2); // filter, cut off 5[Hz]
+        tmp_filterd_fz += limb_param[link_id].prev_act_force_z;
     }
 
-    return hrp::Vector3(tmpzmpx / tmpfz, tmpzmpy / tmpfz, zmp_z);
-
-    // if (tmpfz2 < contact_decision_threshold) {
-    //     ret_zmp = act_zmp;
-    //     return false; // in the air
-    // } else {
-    //     ret_zmp = hrp::Vector3(tmpzmpx / tmpfz, tmpzmpy / tmpfz, zmp_z);
-    //     return true; // on ground
-    // }
-}
-
-hrp::Vector3 calcCOPFromRobotState(const hrp::BodyPtr& act_robot,
-                                   const std::vector<LinkConstraint>& constraints,
-                                   const LinkConstraint::ConstraintType type_thre)
-{
-    hrp::Vector3 cop_pos = hrp::Vector3::Zero();
-    double sum_weight = 0;
-
-    for (const LinkConstraint& constraint : constraints) {
-        if (constraint.getConstraintType() >= type_thre || !constraint.isZmpCalcTarget()) continue;
-        const double weight = constraint.getCOPWeight();
-        const hrp::Link* const target = act_robot->link(constraint.getLinkId());
-        cop_pos += constraint.calcActualTargetPosFromLinkState(target->p, target->R) * weight;
-        sum_weight += weight;
+    if (tmp_filterd_fz < contact_decision_threshold) {
+        ret_zmp = cog; // 昔はact_zmpだったけど空中はcogと一致しているほうが都合がいい？
+        return false; // in the air
+    } else {
+        ret_zmp = hrp::Vector3(tmp_zmpx / tmp_fz, tmp_zmpy / tmp_fz, zmp_z);
+        return true; // on ground
     }
-    if (sum_weight > 0) cop_pos /= sum_weight;
-
-    return cop_pos;
 }
 
 // hrp::Vector3 StateEstimator::calcCOPFromRobotState(const hrp::BodyPtr& act_robot,

--- a/rtc/AutoBalanceStabilizer/StateEstimator.cpp
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.cpp
@@ -12,6 +12,21 @@
 
 namespace hrp {
 
+StateEstimator::StateEstimator(const hrp::BodyPtr& _robot, const std::string& _comp_name, const double _dt, std::mutex& _mutex, const std::vector<int>& link_indices)
+    : m_robot(_robot),
+      comp_name(_comp_name),
+      dt(_dt),
+      m_mutex(_mutex)
+{
+    for (const auto& id : link_indices) {
+        limb_param.emplace(id, limbParam());
+    }
+}
+
+void StateEstimator::calcStates(const stateInputData& input_data)
+{
+}
+
 hrp::Vector3 calcActZMP(const hrp::BodyPtr& act_robot,
                         const std::vector<LinkConstraint>& constraints,
                         const double zmp_z)
@@ -85,26 +100,45 @@ hrp::Vector3 calcCOPFromRobotState(const hrp::BodyPtr& act_robot,
     return cop_pos;
 }
 
-hrp::Matrix33 calcCOPRotationFromRobotState(const hrp::BodyPtr& act_robot,
-                                            const std::vector<LinkConstraint>& constraints,
-                                            const LinkConstraint::ConstraintType type_thre)
-{
-    Eigen::Quaternion<double> cop_quat = Eigen::Quaternion<double>::Identity();
-    double sum_weight = 0;
-    constexpr double EPS = 1e-6;
+// hrp::Vector3 StateEstimator::calcCOPFromRobotState(const hrp::BodyPtr& act_robot,
+//                                    const std::vector<LinkConstraint>& constraints,
+//                                    const LinkConstraint::ConstraintType type_thre)
+// {
+//     hrp::Vector3 cop_pos = hrp::Vector3::Zero();
+//     double sum_weight = 0;
 
-    for (const LinkConstraint& constraint : constraints) {
-        const double weight = constraint.getCOPWeight();
-        if (constraint.getConstraintType() >= type_thre || !constraint.isZmpCalcTarget() ||
-            weight < EPS /* to avoid zero division */) continue;
-        sum_weight += weight;
+//     for (const LinkConstraint& constraint : constraints) {
+//         if (constraint.getConstraintType() >= type_thre || !constraint.isZmpCalcTarget()) continue;
+//         const double weight = constraint.getCOPWeight();
+//         const hrp::Link* const target = act_robot->link(constraint.getLinkId());
+//         cop_pos += constraint.calcActualTargetPosFromLinkState(target->p, target->R) * weight;
+//         sum_weight += weight;
+//     }
+//     if (sum_weight > 0) cop_pos /= sum_weight;
 
-        const hrp::Link* const target = act_robot->link(constraint.getLinkId());
-        const Eigen::Quaternion<double> contact_quat(constraint.calcActualTargetRotFromLinkState(target->R));
-        cop_quat = cop_quat.slerp(weight / sum_weight, contact_quat);
-    }
+//     return cop_pos;
+// }
 
-    return cop_quat.toRotationMatrix();
-}
+// hrp::Matrix33 StateEstimator::calcCOPRotationFromRobotState(const hrp::BodyPtr& act_robot,
+//                                             const std::vector<LinkConstraint>& constraints,
+//                                             const LinkConstraint::ConstraintType type_thre)
+// {
+//     Eigen::Quaternion<double> cop_quat = Eigen::Quaternion<double>::Identity();
+//     double sum_weight = 0;
+//     constexpr double EPS = 1e-6;
+
+//     for (const LinkConstraint& constraint : constraints) {
+//         const double weight = constraint.getCOPWeight();
+//         if (constraint.getConstraintType() >= type_thre || !constraint.isZmpCalcTarget() ||
+//             weight < EPS /* to avoid zero division */) continue;
+//         sum_weight += weight;
+
+//         const hrp::Link* const target = act_robot->link(constraint.getLinkId());
+//         const Eigen::Quaternion<double> contact_quat(constraint.calcActualTargetRotFromLinkState(target->R));
+//         cop_quat = cop_quat.slerp(weight / sum_weight, contact_quat);
+//     }
+
+//     return cop_quat.toRotationMatrix();
+// }
 
 }

--- a/rtc/AutoBalanceStabilizer/StateEstimator.cpp
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.cpp
@@ -25,6 +25,12 @@ StateEstimator::StateEstimator(const hrp::BodyPtr& _robot, const std::string& _c
 
 void StateEstimator::calcStates(const stateInputData& input_data)
 {
+    // Actual world frame =>
+    base_rpy = hrp::rpyFromRot(m_robot->rootLink()->R);
+    foot_origin_coord = input_data.constraints.calcFootOriginCoord(m_robot);
+
+    // cog
+    cog = m_robot->calcCM();
 }
 
 hrp::Vector3 calcActZMP(const hrp::BodyPtr& act_robot,

--- a/rtc/AutoBalanceStabilizer/StateEstimator.cpp
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.cpp
@@ -65,6 +65,8 @@ void StateEstimator::calcStates(const stateInputData& input_data)
         }
     }
     foot_frame_cogvel = cogvel_filter->passFilter(foot_frame_cogvel);
+    foot_frame_cp = foot_frame_cog + foot_frame_cogvel / std::sqrt(g_acc / (foot_frame_cog - foot_frame_zmp)(2));
+    base_frame_cp = m_robot->rootLink()->R.transpose() * (static_cast<hrp::Vector3>(foot_origin_coord * foot_frame_cp) - m_robot->rootLink()->p); // 以前は高さをzmp(2)にして地面上に投影していたが，3次元CPとして扱うことにした
 
     for (const auto& constraint : input_data.constraints.constraints) {
         const int link_id = constraint.getLinkId();
@@ -72,6 +74,7 @@ void StateEstimator::calcStates(const stateInputData& input_data)
         limb_param[link_id].foot_frame_ee_coord.translation() = foot_origin_coord.inverse() * constraint.calcActualTargetPosFromLinkState(target->p, target->R);
         limb_param[link_id].foot_frame_ee_coord.linear() = foot_origin_coord.linear().transpose() * constraint.calcActualTargetRotFromLinkState(target->R);
     }
+    // <= foot_origin frame
 
     // set prev values
     prev_const_idx = input_data.cur_const_idx;

--- a/rtc/AutoBalanceStabilizer/StateEstimator.h
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.h
@@ -81,23 +81,6 @@ class StateEstimator
     void calcStates(const stateInputData& input_data);
     bool calcZMP(hrp::Vector3& ret_zmp, const hrp::ConstraintsWithCount& constraints, const double zmp_z);
     inline bool isContact(const int idx) { return limb_param[idx].prev_act_force_z > contact_decision_threshold; };
-
-    // hrp::Vector3 calcCOPFromRobotState(const hrp::BodyPtr& act_robot,
-    //                                    const std::vector<LinkConstraint>& constraints,
-    //                                    const LinkConstraint::ConstraintType type_thre = LinkConstraint::FLOAT);
-
-    // hrp::Matrix33 calcCOPRotationFromRobotState(const hrp::BodyPtr& act_robot,
-    //                                             const std::vector<LinkConstraint>& constraints,
-    //                                             const LinkConstraint::ConstraintType type_thre = LinkConstraint::FLOAT);
-
-    // inline hrp::Vector3 calcCP(const hrp::Vector3& cog, const hrp::Vector3& cog_vel, const double zmp_z,
-    //                            const double g_acc = 9.80665)
-    // {
-    //     return cog + cog_vel / std::sqrt(g_acc / (cog[2] - zmp_z));
-    // }
-
-    // bool calcIsOnGround();
-
 };
 
 }

--- a/rtc/AutoBalanceStabilizer/StateEstimator.h
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.h
@@ -10,6 +10,7 @@
 #define STATEESTIMATOR_H
 
 #include <cmath>
+#include <mutex>
 #include <Eigen/Geometry>
 #include <hrpUtil/EigenTypes.h>
 #include <hrpModel/Body.h>
@@ -17,39 +18,62 @@
 
 namespace hrp {
 
-struct stateValues
+struct stateInputData
 {
-    // hrp::BodyPtr body;
-    hrp::dvector q;
-    hrp::Vector3 cog;
-    hrp::Vector3 cp; // Capture Point
-    hrp::Vector3 zmp;
-    Eigen::Isometry3d foot_origin_coord;
-
-    hrp::Vector3 transformFootOriginCoord(const hrp::Vector3& target) {
-        return foot_origin_coord.linear() * (target - foot_origin_coord.translation());
-    }
+    hrp::dvector q_current;
+    hrp::Vector3 rpy;
+    std::vector<hrp::dvector6> wrenches;
+    hrp::ConstraintsWithCount constraints;
+    double zmp_z; // 常にreferenceの値を用いる
 };
 
-hrp::Vector3 calcActZMP(const hrp::BodyPtr& act_robot,
-                        const std::vector<LinkConstraint>& constraints,
-                        const double zmp_z);
-
-hrp::Vector3 calcCOPFromRobotState(const hrp::BodyPtr& act_robot,
-                                   const std::vector<LinkConstraint>& constraints,
-                                   const LinkConstraint::ConstraintType type_thre = LinkConstraint::FLOAT);
-
-hrp::Matrix33 calcCOPRotationFromRobotState(const hrp::BodyPtr& act_robot,
-                                            const std::vector<LinkConstraint>& constraints,
-                                            const LinkConstraint::ConstraintType type_thre = LinkConstraint::FLOAT);
-
-inline hrp::Vector3 calcCP(const hrp::Vector3& cog, const hrp::Vector3& cog_vel, const double zmp_z,
-                           const double g_acc = 9.80665)
+struct limbParam
 {
-    return cog + cog_vel / std::sqrt(g_acc / (cog[2] - zmp_z));
-}
+    hrp::Vector3 contact_cop_info = hrp::Vector3::Zero();
+    double prev_act_force_z = 0;
+};
 
-bool calcIsOnGround();
+class StateEstimator
+{
+  private:
+    hrp::BodyPtr m_robot;
+    std::mutex& m_mutex; // This is the reference to the mutex of AutoBalanceStabilizer class
+    const std::string comp_name;
+    const double dt;
+
+    hrp::Vector3 cog = hrp::Vector3::Zero();;
+    hrp::Vector3 zmp = hrp::Vector3::Zero();;
+    hrp::Vector3 base_rpy = hrp::Vector3::Zero();;
+
+    Eigen::Isometry3d foot_origin_coord;
+
+    std::map<int, limbParam> limb_param;
+    bool on_ground = false;
+    double contact_decision_threshold = 50; // [N]
+
+  public:
+    StateEstimator(const hrp::BodyPtr& _robot, const std::string& _comp_name, const double _dt, std::mutex& _mutex, const std::vector<int>& link_indices);
+
+    void calcStates(const stateInputData& input_data);
+    bool calcZMP(hrp::Vector3& ret_zmp, const hrp::ConstraintsWithCount& constraints, const double zmp_z);
+
+    // hrp::Vector3 calcCOPFromRobotState(const hrp::BodyPtr& act_robot,
+    //                                    const std::vector<LinkConstraint>& constraints,
+    //                                    const LinkConstraint::ConstraintType type_thre = LinkConstraint::FLOAT);
+
+    // hrp::Matrix33 calcCOPRotationFromRobotState(const hrp::BodyPtr& act_robot,
+    //                                             const std::vector<LinkConstraint>& constraints,
+    //                                             const LinkConstraint::ConstraintType type_thre = LinkConstraint::FLOAT);
+
+    // inline hrp::Vector3 calcCP(const hrp::Vector3& cog, const hrp::Vector3& cog_vel, const double zmp_z,
+    //                            const double g_acc = 9.80665)
+    // {
+    //     return cog + cog_vel / std::sqrt(g_acc / (cog[2] - zmp_z));
+    // }
+
+    // bool calcIsOnGround();
+
+};
 
 }
 

--- a/rtc/AutoBalanceStabilizer/StateEstimator.h
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.h
@@ -15,6 +15,7 @@
 #include <hrpUtil/EigenTypes.h>
 #include <hrpModel/Body.h>
 #include "LinkConstraint.h"
+#include "../TorqueFilter/IIRFilter.h"
 
 namespace hrp {
 
@@ -32,6 +33,8 @@ struct limbParam
 {
     hrp::Vector3 contact_cop_info = hrp::Vector3::Zero();
     double prev_act_force_z = 0;
+    bool contact_states = false;
+    Eigen::Isometry3d foot_frame_ee_coord = Eigen::Isometry3d::Identity();
 };
 
 class StateEstimator
@@ -41,22 +44,41 @@ class StateEstimator
     std::mutex& m_mutex; // This is the reference to the mutex of AutoBalanceStabilizer class
     const std::string comp_name;
     const double dt;
+    static constexpr double g_acc = 9.80665; // [m/s^2]
 
-    hrp::Vector3 cog = hrp::Vector3::Zero();;
-    hrp::Vector3 zmp = hrp::Vector3::Zero();;
-    hrp::Vector3 base_rpy = hrp::Vector3::Zero();;
+    // world frame
+    hrp::Vector3 cog = hrp::Vector3::Zero();
+    hrp::Vector3 zmp = hrp::Vector3::Zero();
+    hrp::Vector3 base_rpy = hrp::Vector3::Zero();
 
-    Eigen::Isometry3d foot_origin_coord;
+    // base-link frame
+    hrp::Vector3 base_frame_zmp = hrp::Vector3::Zero();
+
+    // foot-origion frame
+    hrp::Vector3 foot_frame_cog = hrp::Vector3::Zero();
+    hrp::Vector3 prev_foot_frame_cog = hrp::Vector3::Zero();
+    hrp::Vector3 foot_frame_zmp = hrp::Vector3::Zero();
+    hrp::Vector3 foot_frame_cogvel = hrp::Vector3::Zero();
+
+    Eigen::Isometry3d foot_origin_coord = Eigen::Isometry3d::Identity();
+    Eigen::Isometry3d prev_foot_origin_coord = Eigen::Isometry3d::Identity();
 
     std::map<int, limbParam> limb_param;
     bool on_ground = false;
-    double contact_decision_threshold = 50; // [N]
+    bool prev_on_ground = false;
+    double contact_decision_threshold = 25; // [N]
+
+    size_t prev_const_idx = 0;
+    size_t jump_time_count = 0;
+    double jump_initial_velocity_z = 0;
+    std::unique_ptr<FirstOrderLowPassFilter<hrp::Vector3>> cogvel_filter;
 
   public:
     StateEstimator(const hrp::BodyPtr& _robot, const std::string& _comp_name, const double _dt, std::mutex& _mutex, const std::vector<int>& link_indices);
 
     void calcStates(const stateInputData& input_data);
     bool calcZMP(hrp::Vector3& ret_zmp, const hrp::ConstraintsWithCount& constraints, const double zmp_z);
+    inline bool isContact(const int idx) { return limb_param[idx].prev_act_force_z > contact_decision_threshold; };
 
     // hrp::Vector3 calcCOPFromRobotState(const hrp::BodyPtr& act_robot,
     //                                    const std::vector<LinkConstraint>& constraints,

--- a/rtc/AutoBalanceStabilizer/StateEstimator.h
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.h
@@ -25,6 +25,7 @@ struct stateInputData
     std::vector<hrp::dvector6> wrenches;
     hrp::ConstraintsWithCount constraints;
     double zmp_z; // 常にreferenceの値を用いる
+    size_t cur_const_idx;
 };
 
 struct limbParam

--- a/rtc/AutoBalanceStabilizer/StateEstimator.h
+++ b/rtc/AutoBalanceStabilizer/StateEstimator.h
@@ -53,12 +53,14 @@ class StateEstimator
 
     // base-link frame
     hrp::Vector3 base_frame_zmp = hrp::Vector3::Zero();
+    hrp::Vector3 base_frame_cp = hrp::Vector3::Zero();
 
     // foot-origion frame
     hrp::Vector3 foot_frame_cog = hrp::Vector3::Zero();
     hrp::Vector3 prev_foot_frame_cog = hrp::Vector3::Zero();
     hrp::Vector3 foot_frame_zmp = hrp::Vector3::Zero();
     hrp::Vector3 foot_frame_cogvel = hrp::Vector3::Zero();
+    hrp::Vector3 foot_frame_cp = hrp::Vector3::Zero();
 
     Eigen::Isometry3d foot_origin_coord = Eigen::Isometry3d::Identity();
     Eigen::Isometry3d prev_foot_origin_coord = Eigen::Isometry3d::Identity();

--- a/rtc/AutoBalanceStabilizer/Utility.h
+++ b/rtc/AutoBalanceStabilizer/Utility.h
@@ -86,6 +86,23 @@ inline void copyJointAnglesFromRobotModel(hrp::dvector& joint_angles,
     }
 }
 
+inline hrp::Matrix33 alignZaxis(const hrp::Matrix33& orig_rot, const hrp::Vector3& n = hrp::Vector3::UnitZ())
+{
+    // Eigen::Isometry3d::LinearPart rot;
+    hrp::Matrix33 rot;
+
+    hrp::Vector3 en = n / n.norm();
+    const hrp::Vector3 ex = hrp::Vector3::UnitX();
+    hrp::Vector3 xv1(orig_rot * ex);
+    xv1 = xv1 - xv1.dot(en) * en;
+    xv1.normalize();
+    hrp::Vector3 yv1(en.cross(xv1));
+    rot(0,0) = xv1(0); rot(1,0) = xv1(1); rot(2,0) = xv1(2);
+    rot(0,1) = yv1(0); rot(1,1) = yv1(1); rot(2,1) = yv1(2);
+    rot(0,2) = en(0);  rot(1,2) = en(1);  rot(2,2) = en(2);
+
+    return rot;
 }
 
+}
 #endif // ABST_UTILITY_H


### PR DESCRIPTION
stateEstimatorにStabilizerで行っていたactualの状態推定に相当する部分を実装しました．
現在はcalcStatesがonExecute()の最初のほうで呼ばれているだけで値はどこにも使われていません．
（https://github.com/kindsenior/hrpsys-base/pull/10 は結局分離できなくてこのPRに含まれています）

この後の手順として，

- act_seのデータをStabilizerに渡して，calcActualParametersのうち重複している部分を消す．
- calcTargetParameters相当の部分をstateEstimaorに実装する
- Stabilizerをconstraint対応する．

です．
constraintを使うことで支持足座標の位置が変わったりするので上記３つはまとまったPRになる予定です．