### PR TITLE
send tauRef from StateHolder to RobotHardware

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -324,6 +324,13 @@ class HrpsysConfigurator(object):
             else:
                 connectPorts(self.sh.port("qOut"), self.rh.port("qRef"))
 
+        # connection for reference torque
+        if self.st:
+            connectPorts(self.sh.port("tqOut"), self.st.port("tauRef"))
+            connectPorts(self.st.port("tau"), self.rh.port("tauRef"))
+        else:
+            connectPorts(self.sh.port("tqOut"), self.rh.port("tauRef"))
+
         # only for kinematics simulator
         if rtm.findPort(self.rh.ref, "basePoseRef"):
             self.kinematics_only_mode = True
@@ -409,7 +416,6 @@ class HrpsysConfigurator(object):
                 connectPorts(self.rfu.port("refFootOriginExtMomentIsHoldValue"), self.abc.port("refFootOriginExtMomentIsHoldValue"))
             if self.octd:
                 connectPorts(self.abc.port("contactStates"), self.octd.port("contactStates"))
-            connectPorts(self.st.port("tau"), self.rh.port("tauRef"))
             connectPorts(self.st.port("RobotHardwareService"), self.rh.port("RobotHardwareService"))
 
         # ref force moment connection

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -63,6 +63,7 @@ Stabilizer::Stabilizer(RTC::Manager* manager)
     // <rtc-template block="initializer">
     m_qCurrentIn("qCurrent", m_qCurrent),
     m_qRefIn("qRef", m_qRef),
+    m_tauRefIn("tauRef", m_tauRef),
     m_rpyIn("rpy", m_rpy),
     m_zmpRefIn("zmpRef", m_zmpRef),
     m_StabilizerServicePort("StabilizerService"),
@@ -128,6 +129,7 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
   // Set InPort buffers
   addInPort("qCurrent", m_qCurrentIn);
   addInPort("qRef", m_qRefIn);
+  addInPort("tauRef", m_tauRefIn);
   addInPort("rpy", m_rpyIn);
   addInPort("zmpRef", m_zmpRefIn);
   addInPort("basePosIn", m_basePosIn);
@@ -570,6 +572,9 @@ RTC::ReturnCode_t Stabilizer::onExecute(RTC::UniqueId ec_id)
   if (m_qRefIn.isNew()) {
     m_qRefIn.read();
   }
+  if (m_tauRefIn.isNew()) {
+    m_tauRefIn.read();
+  }
   if (m_qCurrentIn.isNew()) {
     m_qCurrentIn.read();
   }
@@ -672,6 +677,11 @@ RTC::ReturnCode_t Stabilizer::onExecute(RTC::UniqueId ec_id)
       for ( int i = 0; i < m_robot->numJoints(); i++ ){
         m_qRef.data[i] = m_robot->joint(i)->q;
         m_tau.data[i] = m_robot->joint(i)->u;
+      }
+      if ( m_robot->numJoints() == m_tauRef.data.length() ) {
+        for ( int i = 0; i < m_robot->numJoints(); i++ ){
+          m_tau.data[i] += m_tauRef.data[i];
+        }
       }
       m_zmp.data.x = rel_act_zmp(0);
       m_zmp.data.y = rel_act_zmp(1);

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -163,6 +163,7 @@ class Stabilizer
   // </rtc-template>
   RTC::TimedDoubleSeq m_qCurrent;
   RTC::TimedDoubleSeq m_qRef;
+  RTC::TimedDoubleSeq m_tauRef;
   RTC::TimedDoubleSeq m_tau;
   RTC::TimedOrientation3D m_rpy;
   RTC::TimedPoint3D m_zmpRef;
@@ -197,6 +198,7 @@ class Stabilizer
   // <rtc-template block="inport_declare">
   RTC::InPort<RTC::TimedDoubleSeq> m_qCurrentIn;
   RTC::InPort<RTC::TimedDoubleSeq> m_qRefIn;
+  RTC::InPort<RTC::TimedDoubleSeq> m_tauRefIn;
   RTC::InPort<RTC::TimedOrientation3D> m_rpyIn;
   RTC::InPort<RTC::TimedPoint3D> m_zmpRefIn;
   RTC::InPort<RTC::TimedPoint3D> m_basePosIn;

--- a/rtc/StateHolder/StateHolder.cpp
+++ b/rtc/StateHolder/StateHolder.cpp
@@ -243,7 +243,12 @@ RTC::ReturnCode_t StateHolder::onExecute(RTC::UniqueId ec_id)
     }
     if (m_requestGoActual || (m_q.data.length() == 0 && m_currentQ.data.length() > 0)){
         m_q = m_currentQ;
-        if (m_q.data.length() != m_tq.data.length()) m_tq.data.length(m_q.data.length());
+        if (m_q.data.length() != m_tq.data.length()) {
+          m_tq.data.length(m_q.data.length());
+          for(size_t i=0;i<m_tq.data.length();i++){
+            m_tq.data[i] = 0;
+          }
+        }
         // Reset reference wrenches to zero
         for (unsigned int i=0; i<m_wrenchesIn.size(); i++){
             m_wrenches[i].data[0] = m_wrenches[i].data[1] = m_wrenches[i].data[2] = 0.0;


### PR DESCRIPTION
@Utaro-M のハンドにeuslispからトルク指令を送るための変更です。

これまでトルク指令値の流れは、
* euslisp->StateHolder
* Stabilizer->RobotHardware

の部分はあったのですが、StateHolder->Stabilizerの部分がなかったので、追加しました。

また、StateHolderのバグを見つけたので直しました。https://github.com/fkanehiro/hrpsys-base/pull/1316